### PR TITLE
Fix eslint and skip symlinks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,19 @@
 module.exports = {
-    "extends": "google",
-    rules: {
-      // This is silly. Negated conditions are highly useful and often much more concise than
-      // their complements.
-      "no-negated-condition": "off",
-      // pre-ES6 engines need to be able to use objects as maps
-      "guard-for-in": "off"
-    }
+  "extends": "google",
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  "rules": {
+    // don't dangle commas
+    "comma-dangle": ["error", "never"],
+    // pre-ES6 engines need to be able to use objects as maps
+    "guard-for-in": "off",
+    // increase max line length
+    "max-len": ["error", { "code": 120 }],
+    // This is silly. Negated conditions are highly useful and often much more concise than
+    // their complements.
+    "no-negated-condition": "off",
+    // allow use of var
+    "no-var": "off"
+  }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ test/coverage/
 
 # Dependencies #
 ################
-node_modules/
+node_modules
 
 # Logs #
 ########

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "conventional-recommended-bump": "^0.3.0",
     "cz-conventional-changelog": "^1.2.0",
     "eslint": "^3.6.1",
-    "eslint-config-google": "^0.6.0",
+    "eslint-config-google": "^0.7.0",
     "husky": "^0.13.3",
     "mocha": "^3.1.2",
     "nyc": "^10.0.0",

--- a/resolve.js
+++ b/resolve.js
@@ -194,7 +194,12 @@ const resolvePlugins = function(pack, projectDir, prefix, depth) {
         var pluginPack = null;
 
         try {
-          pluginPackPath = path.resolve(p, file, 'package.json');
+          var pluginPath = path.resolve(p, file);
+          if (fs.lstatSync(pluginPath).isSymbolicLink()) {
+            return false;
+          }
+
+          pluginPackPath = path.resolve(pluginPath, 'package.json');
           pluginPack = require(pluginPackPath);
           // see if the plugin provides a flag to override the app version
           var overrideVersion = pluginPack.overrideVersion;


### PR DESCRIPTION
The linter was on an old version of `eslint-config-google` (compared to `opensphere`). Updating broke linting, so rules were updated to pass with the existing code.

In the resolver, any paths prefixed with `opensphere-plugin-` or `opensphere-config-` will be ignored if the path is a symlink. This prevents duplicate detection when using a shared `node_modules` directory with yarn.