### PR TITLE
Resolve node_modules paths to support yarn workspaces.

### DIFF
--- a/core.js
+++ b/core.js
@@ -99,8 +99,8 @@ const resolvePlugins = function(rootProjectPath, alreadyResolved, pack, projectD
         }
 
         // check the peerDependencies semver
-        var pluginPackPath = null;
-        var pluginPack = null;
+        var pluginPackPath;
+        var pluginPack;
 
         try {
           var pluginPath = path.resolve(p, file);
@@ -206,7 +206,8 @@ const resolvePackage = function(rootProjectPath, alreadyResolved, name, depth, o
     path.resolve(optDependent, 'node_modules', name),
     path.resolve(optDependent, 'bower_components', name),
     path.resolve(rootProjectPath, 'node_modules', name),
-    path.resolve(rootProjectPath, 'bower_components', name)
+    path.resolve(rootProjectPath, 'bower_components', name),
+    path.resolve(rootProjectPath, '../../node_modules', name)
   ];
 
   var pack = null;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "config": {
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     },
     "validate-commit-msg": {
       "helpMessage": "\nPlease fix your commit message (consider using 'npm i -g commitizen'). Well-formatted commit messages allow us to automate our changelog and npm releases.\n\nExamples:\n\"fix(copy-view): Fixed an error when resolving paths for view directories\"\n\"feat(gcc): Added support for defines\"\n\nIf you have installed commitizen, try running 'git cz'."
@@ -95,6 +95,7 @@
     "object.values": "^1.0.3",
     "require-all": "^2.0.0",
     "require-glob": "^3.2.0",
+    "resolve": "^1.5.0",
     "rimraf": "^2.5.4",
     "semver": "^5.3.0",
     "simple-grep": "0.0.1",

--- a/plugins/gcc/options.js
+++ b/plugins/gcc/options.js
@@ -31,6 +31,13 @@ const resolver = function(pack, projectDir) {
         item = item.substring(1);
       }
 
+      // try to resolve the item by walking node_modules
+      var packagePath = utils.resolveModulePath(item, projectDir);
+      if (packagePath) {
+        return (exclusion ? '!' : '') + packagePath;
+      }
+
+      // resolve the path from the project directory if not found in node_modules
       return (exclusion ? '!' : '') +
         utils.flattenPath(path.resolve(projectDir, item));
     };

--- a/plugins/scss/index.js
+++ b/plugins/scss/index.js
@@ -25,8 +25,14 @@ const resolver = function(pack, projectDir, depth) {
 
   if (!compassPath && pack.dependencies &&
       pack.dependencies['compass-mixins']) {
-    compassPath = utils.flattenPath(path.resolve(
+    // try to resolve compass by walking node_modules
+    compassPath = utils.resolveModulePath('compass-mixins/lib', projectDir);
+
+    if (!compassPath) {
+      // resolve the path from the project directory if not found in node_modules
+      compassPath = utils.flattenPath(path.resolve(
           projectDir, 'node_modules/compass-mixins/lib'));
+    }
 
     console.log('Compass resolved to ' + compassPath);
     scssPaths.push(compassPath);

--- a/resolve.js
+++ b/resolve.js
@@ -27,7 +27,7 @@ if (process.argv.length < 3 || !process.argv[2]) {
 var plugins = pluginUtils.load();
 var outputDir = path.resolve(process.cwd(), process.argv[2]);
 
-core.resolvePackage(null, null, process.cwd(), 0, undefined, plugins)
+core.resolvePackage(undefined, undefined, process.cwd(), 0, undefined, plugins)
   .then(function() {
     console.log();
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,6 +2,7 @@
 
 const utils = require('../utils');
 const expect = require('chai').expect;
+const path = require('path');
 
 describe('utils', () => {
   it('should detect app packages', () => {
@@ -124,5 +125,23 @@ describe('utils', () => {
     expect(utils.getIndent(1)).to.equal(' \u221F ');
     expect(utils.getIndent(2)).to.equal('   \u221F ');
     expect(utils.getIndent(3)).to.equal('     \u221F ');
+  });
+
+  it('should get the package for a module', () => {
+    expect(utils.getPackage('not-a-real-package')).to.be.undefined;
+
+    var pack = utils.getPackage('chai');
+    expect(pack).not.to.be.undefined;
+    expect(pack.name).to.equal('chai');
+  });
+
+  it('should get the path for a module', () => {
+    expect(utils.resolveModulePath('not-a-real-package')).to.be.undefined;
+
+    var chaiPath = utils.resolveModulePath('chai');
+    expect(chaiPath).to.equal(path.join(__dirname, '..', 'node_modules', 'chai'));
+
+    var chaiJsPath = utils.resolveModulePath(path.join('chai', 'lib', 'chai.js'));
+    expect(chaiJsPath).to.equal(path.join(chaiPath, 'lib', 'chai.js'));
   });
 });

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const resolve = require('resolve');
 
 /**
  * If a package is designated as an app.
@@ -94,7 +95,6 @@ const getPrioritySort = function(map) {
   };
 };
 
-
 /**
  * @param {number} depth The depth to indent
  * @return {string} The indent string
@@ -112,6 +112,40 @@ const getIndent = function(depth) {
   return indent;
 };
 
+/**
+ * Get the `package.json` as a JSON object for a package.
+ * @param {string} packageName The package name.
+ * @return {Object|undefined} The resolved `package.json`, or undefined if not found.
+ */
+const getPackage = function(packageName) {
+  try {
+    return require(path.join(packageName, 'package.json'));
+  } catch (e) {
+  }
+
+  return undefined;
+};
+
+/**
+ * Resolve the absolute path for a file/directory under `node_modules`.
+ * @param {string} modulePath The relative path. Should begin with the module name.
+ * @param {string=} optBasedir Optional paths to resolve module location from.
+ * @return {string|undefined} The resolved path, or undefined if the module could not be found.
+ */
+const resolveModulePath = function(modulePath, optBasedir) {
+  try {
+    var match = modulePath.match(/([^/]+)\/?(.*)/);
+    if (match && match[1]) {
+      var basePath = path.dirname(resolve.sync(path.join(match[1], 'package.json'), {
+        basedir: optBasedir
+      }));
+      return path.join(basePath, match[2]);
+    }
+  } catch (e) {
+  }
+
+  return undefined;
+};
 
 module.exports = {
   isAppPackage: isAppPackage,
@@ -120,5 +154,7 @@ module.exports = {
   isPluginOfPackage: isPluginOfPackage,
   flattenPath: flattenPath,
   getPrioritySort: getPrioritySort,
-  getIndent: getIndent
+  getIndent: getIndent,
+  getPackage: getPackage,
+  resolveModulePath: resolveModulePath
 };


### PR DESCRIPTION
This adds support for yarn workspaces, where `node_modules` may be shared at the workspace project level. A typical hierarchy for a yarn workspace would look like:
```
yarn-workspace-project
+-- node_modules (shared)
+-- workspace-dir
|   +-- project-a
|       +-- node_modules (project-a)
|   +-- project-b
|       +-- node_modules (project-b)
|   +-- project-c
\       +-- node_modules (project-c)
```

The resolver will now look at the shared `node_modules`, as well as providing projects a way to resolve modules using the [resolve](https://www.npmjs.com/package/resolve) package.

These changes are compatible with a standard npm workspace.