### PR TITLE
Detect plugins/configs from symlinks.

### DIFF
--- a/core.js
+++ b/core.js
@@ -103,12 +103,7 @@ const resolvePlugins = function(rootProjectPath, alreadyResolved, pack, projectD
         var pluginPack;
 
         try {
-          var pluginPath = path.resolve(p, file);
-          if (fs.lstatSync(pluginPath).isSymbolicLink()) {
-            return false;
-          }
-
-          pluginPackPath = path.resolve(pluginPath, 'package.json');
+          pluginPackPath = path.resolve(p, file, 'package.json');
           pluginPack = require(pluginPackPath);
           // see if the plugin provides a flag to override the app version
           var overrideVersion = pluginPack.overrideVersion;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -139,7 +139,7 @@ describe('utils', () => {
     expect(utils.resolveModulePath('not-a-real-package')).to.be.undefined;
 
     var chaiPath = utils.resolveModulePath('chai');
-    expect(chaiPath).to.equal(path.join(__dirname, '..', 'node_modules', 'chai'));
+    expect(chaiPath).to.exist;
 
     var chaiJsPath = utils.resolveModulePath(path.join('chai', 'lib', 'chai.js'));
     expect(chaiJsPath).to.equal(path.join(chaiPath, 'lib', 'chai.js'));


### PR DESCRIPTION
Ignoring symlinks was necessary for a yarn workspace workaround that has since been fixed by updating the resolver to properly detect `node_modules` folders. Removing this will allow easily changing which config/plugin projects are detected in the OpenSphere build.

This also fixes a test that would fail in a yarn workspace due to the resolved `chai` dependency being hoisted to the shared `node_modules` directory. The full path is not relevant to the test, only that it is detected and the following file detection succeeds with the same base path.