### PR TITLE
Sort goog.require statements in GCC require-all.js.

### DIFF
--- a/plugins/gcc/src.js
+++ b/plugins/gcc/src.js
@@ -181,7 +181,7 @@ const createRequireAll = function(basePackage, dir) {
       .then(function(list) {
         list = list.filter(function(item) {
           return Boolean(item);
-        });
+        }).sort();
 
         return fs.readFileAsync(
           path.resolve(__dirname, 'require-all-template.js'), 'utf8')

--- a/test/plugins/gcc/src.test.js
+++ b/test/plugins/gcc/src.test.js
@@ -93,8 +93,12 @@ describe('gcc src resolver', function() {
         return fs.readFileAsync(file, 'utf-8');
       })
       .then((content) => {
+        // both files are required
         expect(content).to.contain('goog.require(\'app\')');
         expect(content).to.contain('goog.require(\'util\')');
+
+        // and they are sorted
+        expect(content.indexOf('goog.require(\'app\')')).to.be.lessThan(content.indexOf('goog.require(\'util\')'));
       });
   });
 });


### PR DESCRIPTION
Fixes #13.