### PR TITLE
feat(bootstrap): adds support for resolving bootstrap scss

### DIFF
--- a/test/plugins/scss/scss/should-find-bootstrap-dependency/node-sass-args
+++ b/test/plugins/scss/scss/should-find-bootstrap-dependency/node-sass-args
@@ -1,0 +1,1 @@
+--include-path node_modules/bootstrap/scss

--- a/test/plugins/scss/scss/should-find-bootstrap-dependency/package.json
+++ b/test/plugins/scss/scss/should-find-bootstrap-dependency/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "should-find-bootstrap-dependency",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "dependencies": {
+    "bootstrap": "=4.0.0"
+  }
+}


### PR DESCRIPTION
This makes the code a little bit more generic for resolving 3rd party SCSS files into our builds. It also adds bootstrap as an SCSS provider.

Closes #19