### PR TITLE
feat(themes): Add detection class to theme stylesheets.

### DIFF
--- a/plugins/scss/index.js
+++ b/plugins/scss/index.js
@@ -192,6 +192,10 @@ const writer = function(thisPackage, outputDir) {
                 promises.push(fs.readFileAsync(path.resolve(outputDir, 'combined.scss'), 'utf8')
                   .then(function(fileContents) {
                     console.log('Creating combined.scss for ' + theme + ' theme');
+
+                    // Add the theme name to a class for stylesheet load detection.
+                    fileContents = '.u-loaded-theme { content: "' + theme + '"; }\n' + fileContents;
+
                     // Prepend and Append our theme around the bootstrap entry
                     var bootstrapEntry = '@import \'bootstrap\';';
                     if (theme != 'default') {

--- a/test/plugins/scss/index.test.js
+++ b/test/plugins/scss/index.test.js
@@ -56,6 +56,21 @@ describe('scss resolver', () => {
               expect(args).to.equal(expectedArgs);
               expect(requireAll).to.equal(expectedRequireAll);
             }
+
+            if (pack && pack.build && pack.build.themes) {
+              pack.build.themes.forEach((theme) => {
+                var themeCombinedFile = path.join(outputDir, 'themes', theme + '.combined.scss');
+                var themeArgsFile = path.join(outputDir, 'themes', theme + '.node-sass-args');
+
+                // theme files were written
+                expect(fs.existsSync(themeCombinedFile)).to.be.true;
+                expect(fs.existsSync(themeArgsFile)).to.be.true;
+
+                // theme detection class was added
+                var themeCombined = fs.readFileSync(themeCombinedFile, 'utf-8');
+                expect(themeCombined.startsWith('.u-loaded-theme { content: "' + theme + '"; }')).to.be.true;
+              });
+            }
           });
       });
     }


### PR DESCRIPTION
`onload` doesn’t work in Chrome/Safari for `link` elements, which makes detecting when a stylesheet is loaded a huge pain. We can hack around it by loading the same stylesheet URL in an `img` and use `onerror` to detect when the browser request completes, but that's awful and still prone to other timing problems.

This change adds a class (`.u-loaded-theme`) to each theme that can be used to detect when a theme is loaded. The `content` is set to the theme name, so the app can poll a hidden element for this style change and determine when the stylesheet is ready.