### PR TITLE
fix(bootstrap4): fixed theme selector for bootstrap 4 css check

### DIFF
--- a/plugins/scss/index.js
+++ b/plugins/scss/index.js
@@ -194,7 +194,7 @@ const writer = function(thisPackage, outputDir) {
                     console.log('Creating combined.scss for ' + theme + ' theme');
 
                     // Add the theme name to a class for stylesheet load detection.
-                    fileContents = '.u-loaded-theme { content: "' + theme + '"; }\n' + fileContents;
+                    fileContents = '.u-loaded-theme::before { content: "' + theme + '"; }\n' + fileContents;
 
                     // Prepend and Append our theme around the bootstrap entry
                     var bootstrapEntry = '@import \'bootstrap\';';

--- a/test/plugins/scss/index.test.js
+++ b/test/plugins/scss/index.test.js
@@ -68,7 +68,7 @@ describe('scss resolver', () => {
 
                 // theme detection class was added
                 var themeCombined = fs.readFileSync(themeCombinedFile, 'utf-8');
-                expect(themeCombined.startsWith('.u-loaded-theme { content: "' + theme + '"; }')).to.be.true;
+                expect(themeCombined.startsWith('.u-loaded-theme::before { content: "' + theme + '"; }')).to.be.true;
               });
             }
           });


### PR DESCRIPTION
IE and Edge dont support content in the selector (only in :before or :after). So updated to be the :before selector, then making updates to bootstrap 4 theme switch to use the :before selector