### PR TITLE
feat(electron): Add resolver for packaged electron deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
+    "clone": "^2.1.2",
     "concat-files": "^0.1.0",
     "find": "^0.2.7",
     "glob": "^7.1.1",

--- a/plugins/electron/index.js
+++ b/plugins/electron/index.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+const mkdirp = Promise.promisifyAll({
+  mkdirp: require('mkdirp')
+});
+const path = require('path');
+const utils = require('../../utils');
+const clone = require('clone');
+
+var electronDeps = {};
+
+const resolver = function(pack, projectDir, depth) {
+  if (pack.build && pack.build.electron) {
+    if (!Array.isArray(pack.build.electron)) {
+      throw new Error(path.join(projectDir, 'package.json') + 'build.electron must be an ' +
+          'array of package names to include in the Electron build');
+    }
+
+    var deps = pack.dependencies || {};
+
+    electronDeps = pack.build.electron.reduce(function(result, dep) {
+      if (!(dep in deps)) {
+        throw new Error(path.join(projectDir, 'package.json') + ' build.electron contains "' +
+            dep + '" which does not exist in dependencies');
+      }
+
+      result[dep] = deps[dep];
+      return result;
+    }, electronDeps);
+  }
+
+  return Promise.resolve();
+};
+
+const writer = function(thisPackage, outputDir) {
+  try {
+    var electronPath = utils.resolveModulePath('opensphere-electron');
+    var pack = require(path.resolve(electronPath, 'package.json'));
+  } catch (e) {
+    // no Electron package installed, no big deal
+    return Promise.resolve();
+  }
+
+  var dir = path.join(electronPath, 'app');
+  var file = path.join(dir, 'package.json');
+  console.log('Writing ' + file);
+
+  return mkdirp.mkdirpAsync(dir)
+    .then(function() {
+      // copy from base package
+      var appPack = clone(pack);
+
+      // ditch other deps
+      delete appPack.devDependencies;
+      delete appPack.peerDependencies;
+      delete appPack.optionalDependencies;
+
+      // set dependencies to resolved versions
+      appPack.dependencies = Object.assign(appPack.dependencies, electronDeps);
+      appPack.main = appPack.main.replace(/^app\//, '');
+
+      return fs.writeFileAsync(file, JSON.stringify(appPack, null, 2));
+    });
+};
+
+const clear = function() {
+  electronDeps = {};
+};
+
+module.exports = {
+  resolver: resolver,
+  writer: writer,
+  clear: clear
+};

--- a/test/plugins/electron/electron/should-generate-electron-app-package/expected.json
+++ b/test/plugins/electron/electron/should-generate-electron-app-package/expected.json
@@ -1,0 +1,13 @@
+{
+  "name": "opensphere-electron",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "productName": "Test App",
+  "main": "src/main.js",
+  "dependencies": {
+    "electron-is-dev": "3.0.0",
+    "electron-updater": "10.8.1",
+    "some-package": "1.0.0"
+  }
+}

--- a/test/plugins/electron/electron/should-generate-electron-app-package/opensphere-electron/app/package.json
+++ b/test/plugins/electron/electron/should-generate-electron-app-package/opensphere-electron/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "opensphere-electron",
+  "version": "1.0.0",
+  "main": "src/main.js",
+  "license": "MIT",
+  "productName": "Test App",
+  "dependencies": {
+    "electron-is-dev": "3.0.0",
+    "electron-updater": "10.8.1",
+    "some-package": "1.0.0"
+  }
+}

--- a/test/plugins/electron/electron/should-generate-electron-app-package/opensphere-electron/package.json
+++ b/test/plugins/electron/electron/should-generate-electron-app-package/opensphere-electron/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "opensphere-electron",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "productName": "Test App",
+  "main": "app/src/main.js",
+  "dependencies": {
+    "electron-is-dev": "3.0.0",
+    "electron-updater": "10.8.1"
+  }
+}

--- a/test/plugins/electron/electron/should-generate-electron-app-package/project/package.json
+++ b/test/plugins/electron/electron/should-generate-electron-app-package/project/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "build": {
+    "electron": ["some-package"]
+  },
+  "dependencies": {
+    "some-package": "1.0.0"
+  }
+}

--- a/test/plugins/electron/electron/should-ignore-missing-build-config/project/package.json
+++ b/test/plugins/electron/electron/should-ignore-missing-build-config/project/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/test/plugins/electron/electron/should-ignore-missing-electron-config/project/package.json
+++ b/test/plugins/electron/electron/should-ignore-missing-electron-config/project/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "build": {
+    "type": "app"
+  },
+  "license": "MIT"
+}

--- a/test/plugins/electron/electron/should-ignore-missing-electron-project/project/package.json
+++ b/test/plugins/electron/electron/should-ignore-missing-electron-project/project/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "build": {
+    "electron": ["some-package"]
+  },
+  "dependencies": {
+    "some-package": "1.0.0"
+  }
+}

--- a/test/plugins/electron/index.test.js
+++ b/test/plugins/electron/index.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+const path = require('path');
+const expect = require('chai').expect;
+const electron = require('../../../plugins/electron');
+const rimraf = require('rimraf');
+const utils = require('../../../utils.js');
+
+describe('electron resolver', () => {
+  afterEach(() => {
+    electron.clear();
+    rimraf.sync(path.join(outputDir, '*'));
+  });
+
+  var outputDir = path.join(process.cwd(), '.test');
+  var baseDir = path.join(__dirname, 'electron');
+  var dirs = fs.readdirSync(baseDir);
+
+  dirs.forEach((d) => {
+    var dir = path.join(baseDir, d, 'project');
+
+    try {
+      var pack = require(dir + '/package');
+    } catch (e) {
+      console.error(e);
+    }
+
+    if (pack) {
+      it(d.replace(/-/g, ' '), () => {
+        return electron.resolver(pack, dir, 0)
+          .then(() => {
+            // mock this to just find the sibling directories
+            var old = utils.resolveModulePath;
+            utils.resolveModulePath = (p) => {
+              return path.join(baseDir, d, p);
+            };
+
+            var promise = electron.writer(pack, outputDir);
+
+            // put it back
+            utils.resolveModulePath = old;
+            return promise;
+          })
+          .finally(() => {
+            try {
+              var expected = require(path.join(baseDir, d, 'expected'));
+            } catch (e) {
+              expected = false;
+            }
+
+            try {
+              var generatedAppPack = require(path.join(baseDir, d, 'opensphere-electron', 'app', 'package'));
+            } catch (e) {
+              generatedAppPack = false;
+            }
+
+            expect(generatedAppPack).to.deep.equal(expected);
+          });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Most dependencies for this build are packaged into the web app itself. However, Electron apps allow the use of the web app alongside typical node.js packages. Since those dependencies must be packaged by the electron-package project, we will generate an app/package.json for it to read from all the available plugins.