### PR TITLE
Move missingOverride and unusedPrivateMembers to errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "mocha": "^3.1.2",
     "nyc": "^10.0.0",
     "semantic-release": "^15.9.9",
-    "validate-commit-msg": "^2.8.2",
-    "travis-deploy-once": "^5.0.2"
+    "travis-deploy-once": "^5.0.2",
+    "validate-commit-msg": "^2.8.2"
   }
 }

--- a/plugins/gcc/options-base.js
+++ b/plugins/gcc/options-base.js
@@ -62,6 +62,7 @@ module.exports = {
     'invalidCasts',
     'misplacedTypeAnnotation',
     'missingGetCssName',
+    'missingOverride',
     'missingPolyfill',
     'missingProperties',
     // 'missingProvide',
@@ -80,7 +81,7 @@ module.exports = {
     'undefinedVars',
     'unknownDefines',
     'unusedLocalVariables',
-    // 'unusedPrivateMembers',
+    'unusedPrivateMembers',
     'useOfGoogBase',
     'uselessCode',
     'underscore',
@@ -89,9 +90,7 @@ module.exports = {
   jscomp_warning: [
     // If jscomp_error changes to *, you probably want this one
     // 'lintChecks'
-    'deprecated',
-    'missingOverride',
-    'unusedPrivateMembers'
+    'deprecated'
   ],
   // TODO: can we get rid of these too?
   jscomp_off: [

--- a/test/plugins/scss/scss/should-find-bootstrap-dependency/package.json
+++ b/test/plugins/scss/scss/should-find-bootstrap-dependency/package.json
@@ -5,6 +5,6 @@
   "main": "index.js",
   "keywords": [],
   "dependencies": {
-    "bootstrap": "=4.0.0"
+    "bootstrap": "4.1.3"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Projects with Closure Compiler warnings for missingOverride or unusedPrivateMembers will need to fix those warnings before upgrading. They are now flagged as errors.