### PR TITLE
feat(scss): Resolve scss paths from build config

### DIFF
--- a/plugins/scss/index.js
+++ b/plugins/scss/index.js
@@ -63,6 +63,13 @@ const resolver = function(pack, projectDir, depth) {
     }));
   }
 
+  if (pack.build && pack.build.scssPaths && Array.isArray(pack.build.scssPaths)) {
+    scssPaths = scssPaths.concat(pack.build.scssPaths.map(function(dir) {
+      var p = utils.resolveModulePath(dir, projectDir);
+      return p ? p : path.resolve(projectDir, dir);
+    }));
+  }
+
   // don't include scss entries for app packages other than the root level
   if (pack.build && pack.build.scss && ((!utils.isAppPackage(pack) &&
       utils.isPluginOfPackage(basePackage, pack)) || depth === 0)) {

--- a/test/plugins/scss/scss/should-use-extra-scss-paths/node-sass-args
+++ b/test/plugins/scss/scss/should-use-extra-scss-paths/node-sass-args
@@ -1,0 +1,1 @@
+--include-path node_modules/some-scss-lib/scss

--- a/test/plugins/scss/scss/should-use-extra-scss-paths/package.json
+++ b/test/plugins/scss/scss/should-use-extra-scss-paths/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "should-use-extra-scss-paths",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "scssPaths": ["some-scss-lib/scss"]
+  },
+  "dependencies": {
+    "some-scss-lib": "1.0.0"
+  }
+}


### PR DESCRIPTION
Previously package files had to cram paths into directories.scss, which is not really intended for this purpose. Now you can use build.scssPaths as an array to enumerate resolvable paths like
`package/scss`.