### PR TITLE
Add a function to find lines in files matching a pattern.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "bluebird": "^3.4.6",
     "clone": "^2.1.2",
     "concat-files": "^0.1.0",
-    "find": "^0.2.7",
+    "find": "^0.2.9",
     "glob": "^7.1.1",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
@@ -94,7 +94,6 @@
     "resolve": "^1.5.0",
     "rimraf": "^2.5.4",
     "semver": "^5.3.0",
-    "simple-grep": "0.0.1",
     "underscore": "^1.8.3",
     "yargs": "^11.0.0"
   },

--- a/test/utils-find-lines/README.md
+++ b/test/utils-find-lines/README.md
@@ -1,0 +1,11 @@
+This is a non-JavaScript file used to test if the following lines get matched.
+
+Should match:
+goog.provide('test.readme.Thing1');
+goog.provide('test.readme.Thing2');
+
+Should not match:
+/**
+ * goog.provide('test.readme.Thing3');
+ * goog.provide('test.readme.Thing4');
+ */

--- a/test/utils-find-lines/test.js
+++ b/test/utils-find-lines/test.js
@@ -1,0 +1,19 @@
+goog.provide('test.Thing');
+goog.provide('test.AnotherThing');
+goog.require('test');
+
+/**
+ * Tests if goog.provide('<class>') lines are found correctly.
+ * @constructor
+ */
+test.Thing = function() {
+
+};
+
+/**
+ * Tests if goog.provide('<class>') lines are found correctly.
+ * @constructor
+ */
+test.AnotherThing = function() {
+
+};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -154,4 +154,20 @@ describe('utils', () => {
     var indexPath = utils.resolveModulePath('@semantic-release/changelog/index.js');
     expect(indexPath).to.equal(path.join(modulePath, 'index.js'));
   });
+
+  it('should find matching lines in a directory', () => {
+    var directory = path.join(__dirname, 'utils-find-lines');
+    return utils.findLines(/^goog\.provide\(/, directory).then((matches) => {
+      expect(matches.length).to.equal(2);
+      expect(matches.reduce((total, match) => total + match.lines.length, 0)).to.equal(4);
+    });
+  });
+
+  it('should find matching lines in a directory with a file pattern', () => {
+    var directory = path.join(__dirname, 'utils-find-lines');
+    return utils.findLines(/^goog\.provide\(/, directory, /\.js$/).then((matches) => {
+      expect(matches.length).to.equal(1);
+      expect(matches.reduce((total, match) => total + match.lines.length, 0)).to.equal(2);
+    });
+  });
 });


### PR DESCRIPTION
This replaces simple-grep, which does not concat the stdout buffer from multiple callbacks.

Fixes #32.