### PR TITLE
Copy preload scripts for opensphere-electron.

### DIFF
--- a/plugins/electron/index.js
+++ b/plugins/electron/index.js
@@ -6,29 +6,57 @@ const mkdirp = Promise.promisifyAll({
   mkdirp: require('mkdirp')
 });
 const path = require('path');
+const rimraf = Promise.promisify(require('rimraf'));
 const utils = require('../../utils');
 const clone = require('clone');
 
 var electronDeps = {};
+var preloadScripts = [];
 
-const resolver = function(pack, projectDir, depth) {
-  if (pack.build && pack.build.electron) {
-    if (!Array.isArray(pack.build.electron)) {
-      throw new Error(path.join(projectDir, 'package.json') + 'build.electron must be an ' +
+const resolvePackages = function(pack, projectDir, packages) {
+  if (packages) {
+    if (!Array.isArray(packages)) {
+      throw new Error(path.join(projectDir, 'package.json') + 'build.electron.packages must be an ' +
           'array of package names to include in the Electron build');
     }
 
     var deps = pack.dependencies || {};
 
-    electronDeps = pack.build.electron.reduce(function(result, dep) {
+    electronDeps = packages.reduce(function(result, dep) {
       if (!(dep in deps)) {
-        throw new Error(path.join(projectDir, 'package.json') + ' build.electron contains "' +
+        throw new Error(path.join(projectDir, 'package.json') + ' build.electron.packages contains "' +
             dep + '" which does not exist in dependencies');
       }
 
       result[dep] = deps[dep];
       return result;
     }, electronDeps);
+  }
+};
+
+const resolvePreload = function(pack, projectDir, preload) {
+  if (preload) {
+    if (!Array.isArray(preload)) {
+      throw new Error(path.join(projectDir, 'package.json') + 'build.electron.preload must be a ' +
+          'path to a preload script');
+    }
+
+    preload.forEach(function(script) {
+      var scriptPath = path.resolve(projectDir, script);
+      if (!fs.existsSync(scriptPath)) {
+        throw new Error(path.join(projectDir, 'package.json') + 'build.electron.preload path does not exist: ' +
+            scriptPath);
+      }
+
+      preloadScripts.push(scriptPath);
+    });
+  }
+};
+
+const resolver = function(pack, projectDir, depth) {
+  if (pack.build && pack.build.electron) {
+    resolvePackages(pack, projectDir, pack.build.electron.packages);
+    resolvePreload(pack, projectDir, pack.build.electron.preload);
   }
 
   return Promise.resolve();
@@ -45,35 +73,55 @@ const writer = function(thisPackage, outputDir) {
 
   var dir = path.join(electronPath, 'app');
   var file = path.join(dir, 'package.json');
-  console.log('Writing ' + file);
+  var preloadDir = path.join(dir, 'src', 'preload');
 
-  return mkdirp.mkdirpAsync(dir)
-    .then(function() {
-      // copy from base package
-      var appPack = clone(pack);
+  // recreate the preload script directory. scripts will be copied each time the resolver runs.
+  return rimraf(preloadDir).then(function() {
+    return mkdirp.mkdirpAsync(preloadDir)
+      .then(function() {
+        console.log('Writing ' + file);
 
-      // ditch devDeps other than electron
-      var devDeps = appPack.devDependencies;
-      for (var dep in devDeps) {
-        if (!dep.startsWith('electron')) {
-          delete devDeps[dep];
+        // copy from base package
+        var appPack = clone(pack);
+
+        // ditch devDeps other than electron
+        var devDeps = appPack.devDependencies;
+        for (var dep in devDeps) {
+          if (!dep.startsWith('electron')) {
+            delete devDeps[dep];
+          }
         }
-      }
 
-      // ditch other deps
-      delete appPack.peerDependencies;
-      delete appPack.optionalDependencies;
+        // ditch other deps
+        delete appPack.peerDependencies;
+        delete appPack.optionalDependencies;
 
-      // set dependencies to resolved versions
-      appPack.dependencies = Object.assign(appPack.dependencies, electronDeps);
-      appPack.main = appPack.main.replace(/^app\//, '');
+        // set dependencies to resolved versions
+        appPack.dependencies = Object.assign(appPack.dependencies, electronDeps);
+        appPack.main = appPack.main.replace(/^app\//, '');
 
-      return fs.writeFileAsync(file, JSON.stringify(appPack, null, 2));
-    });
+        return fs.writeFileAsync(file, JSON.stringify(appPack, null, 2));
+      })
+      .then(function() {
+        // get the real path to avoid symlink issues
+        preloadDir = fs.realpathSync(preloadDir);
+
+        // copy each preload script to the target directory
+        return Promise.map(preloadScripts, function(script, idx, arr) {
+          // increment preload file names. Electron will load everything in the directory.
+          var dest = path.join(preloadDir, 'preload' + idx + '.js');
+
+          console.log('Writing Electron preload script: ' + dest);
+
+          return fs.copyFileAsync(script, dest, fs.constants.COPYFILE_EXCL);
+        });
+      });
+  });
 };
 
 const clear = function() {
   electronDeps = {};
+  preloadScripts = [];
 };
 
 module.exports = {

--- a/test/plugins/electron/electron/should-copy-preload-scripts/opensphere-electron/app/src/preload/preload0.js
+++ b/test/plugins/electron/electron/should-copy-preload-scripts/opensphere-electron/app/src/preload/preload0.js
@@ -1,0 +1,1 @@
+console.log('Hello');

--- a/test/plugins/electron/electron/should-copy-preload-scripts/opensphere-electron/app/src/preload/preload1.js
+++ b/test/plugins/electron/electron/should-copy-preload-scripts/opensphere-electron/app/src/preload/preload1.js
@@ -1,0 +1,1 @@
+console.log('World');

--- a/test/plugins/electron/electron/should-copy-preload-scripts/project/package.json
+++ b/test/plugins/electron/electron/should-copy-preload-scripts/project/package.json
@@ -5,7 +5,10 @@
   "license": "MIT",
   "build": {
     "electron": {
-      "packages": ["some-package"]
+      "preload": [
+        "./src/preload.js",
+        "./src/preload-more.js"
+      ]
     }
   },
   "dependencies": {

--- a/test/plugins/electron/electron/should-copy-preload-scripts/project/src/preload-more.js
+++ b/test/plugins/electron/electron/should-copy-preload-scripts/project/src/preload-more.js
@@ -1,0 +1,1 @@
+console.log('World');

--- a/test/plugins/electron/electron/should-copy-preload-scripts/project/src/preload.js
+++ b/test/plugins/electron/electron/should-copy-preload-scripts/project/src/preload.js
@@ -1,0 +1,1 @@
+console.log('Hello');

--- a/test/plugins/electron/electron/should-ignore-missing-electron-project/project/package.json
+++ b/test/plugins/electron/electron/should-ignore-missing-electron-project/project/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "build": {
-    "electron": ["some-package"]
+    "electron": {
+      "packages": ["some-package"]
+    }
   },
   "dependencies": {
     "some-package": "1.0.0"

--- a/test/plugins/electron/index.test.js
+++ b/test/plugins/electron/index.test.js
@@ -57,6 +57,12 @@ describe('electron resolver', () => {
             }
 
             expect(generatedAppPack).to.deep.equal(expected);
+
+            if (pack.build && pack.build.electron && pack.build.electron.preload) {
+              var scriptDir = path.join(baseDir, d, 'opensphere-electron', 'app', 'src', 'preload');
+              var scripts = fs.readdirSync(scriptDir);
+              expect(scripts.length).to.equal(pack.build.electron.preload.length);
+            }
           });
       });
     }


### PR DESCRIPTION
BREAKING CHANGE: This changes the format of the `build.electron` config.

Old config:
```
{
  "electron": ["some-package"]
}
```

New config:
```
{
  "electron": {
    "packages": ["some-package"]
  }
}
```