### PR TITLE
Sort GCC options in ascending package priority.

### DIFF
--- a/plugins/config/index.js
+++ b/plugins/config/index.js
@@ -24,26 +24,9 @@ const resolver = function(pack, projectDir, depth) {
       var readFile = function(file) {
         return fs.readFileAsync(file, 'utf8')
           .then(function(content) {
-            //
-            // use priority if specified, so the config load order can be
-            // controlled by the package. if no priority is present, use the
-            // resolved depth. configs at the root depth will be loaded first.
-            //
-            var configDepth;
-            if (pack.build && pack.build.priority !== undefined) {
-              configDepth = pack.build.priority;
-            } else {
-              configDepth = -depth;
-
-              if (utils.isConfigPackage(pack) || (utils.isPluginPackage(pack) &&
-                  utils.isPluginOfPackage(basePackage, pack))) {
-                configDepth++;
-              }
-            }
-
             configs.push({
               path: file,
-              depth: configDepth || 0,
+              depth: utils.getPackagePriority(pack, depth, basePackage),
               content: JSON.parse(content)
             });
           });

--- a/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
@@ -1,0 +1,9 @@
+{
+  "angular_pass": true,
+  "compilation_level": "simple",
+  "js": ["src/**.js", "src/after/**.js", "src/before/**.js"],
+  "define": ["before", "main", "after"],
+  "externs": ["a.externs.js", "b.externs.js"],
+  "entry_point": ["before", "one", "two", "after"]
+}
+

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package-after.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package-after.json
@@ -1,0 +1,15 @@
+{
+  "name": "should-combine-packages-correctly-after",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "gcc": {
+      "define": ["after"],
+      "entry_point": ["after"],
+      "js": "src/after/**.js"
+    },
+    "priority": 100
+  }
+}

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package-before.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package-before.json
@@ -1,0 +1,15 @@
+{
+  "name": "should-combine-packages-correctly-before",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "gcc": {
+      "define": ["before"],
+      "entry_point": ["before"],
+      "js": "src/before/**.js"
+    },
+    "priority": -100
+  }
+}

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "should-combine-packages-correctly",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "gcc": {
+      "angular_pass": true,
+      "compilation_level": "simple",
+      "js": "src/**.js",
+      "define": ["main"],
+      "externs": ["a.externs.js", "b.externs.js"],
+      "entry_point": ["one", "two"]
+    }
+  }
+}

--- a/utils.js
+++ b/utils.js
@@ -199,6 +199,37 @@ const findLines = function(pattern, directory, filePattern) {
   });
 };
 
+/**
+ * Get the sort priority for a package.
+ * @param {Object} pack The package.
+ * @param {number} depth The package depth.
+ * @param {Object} basePackage The base package.
+ * @return {number} The sort priority.
+ */
+const getPackagePriority = function(pack, depth, basePackage) {
+  //
+  // use priority if specified, so the load order can be controlled by the package.
+  // if no priority is present, use the resolved depth.
+  //
+
+  var priority = 0;
+
+  if (pack) {
+    if (pack.build && pack.build.priority !== undefined) {
+      priority = pack.build.priority;
+    } else {
+      priority = -depth;
+
+      if (isConfigPackage(pack) ||
+          (isPluginPackage(pack) && isPluginOfPackage(basePackage, pack))) {
+        priority++;
+      }
+    }
+  }
+
+  return priority;
+};
+
 module.exports = {
   findLines: findLines,
   isAppPackage: isAppPackage,
@@ -209,5 +240,6 @@ module.exports = {
   getPrioritySort: getPrioritySort,
   getIndent: getIndent,
   getPackage: getPackage,
+  getPackagePriority: getPackagePriority,
   resolveModulePath: resolveModulePath
 };


### PR DESCRIPTION
When GCC encounters duplicate options (like --define), the last one wins. This allows packages to control the order of their options.