### PR TITLE
Deduplicate GCC defines.

### DIFF
--- a/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
@@ -2,7 +2,7 @@
   "angular_pass": true,
   "compilation_level": "simple",
   "js": ["src/**.js", "src/after/**.js", "src/before/**.js"],
-  "define": ["before", "main", "after"],
+  "define": ["before=true", "override=after", "main=true", "after=true"],
   "externs": ["a.externs.js", "b.externs.js"],
   "entry_point": ["before", "one", "two", "after"]
 }

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package-after.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package-after.json
@@ -6,7 +6,7 @@
   "keywords": [],
   "build": {
     "gcc": {
-      "define": ["after"],
+      "define": ["after=true","override=after"],
       "entry_point": ["after"],
       "js": "src/after/**.js"
     },

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package-before.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package-before.json
@@ -6,7 +6,7 @@
   "keywords": [],
   "build": {
     "gcc": {
-      "define": ["before"],
+      "define": ["before=true","override=before"],
       "entry_point": ["before"],
       "js": "src/before/**.js"
     },

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package.json
@@ -9,7 +9,7 @@
       "angular_pass": true,
       "compilation_level": "simple",
       "js": "src/**.js",
-      "define": ["main"],
+      "define": ["main=true","override=main"],
       "externs": ["a.externs.js", "b.externs.js"],
       "entry_point": ["one", "two"]
     }


### PR DESCRIPTION
This ensures GCC options do not contain duplicate `define` keys. The highest priority key will be used.