### PR TITLE
feat(gcc): Add js_output_file to JSON compiler options.

### DIFF
--- a/plugins/gcc/index.js
+++ b/plugins/gcc/index.js
@@ -84,6 +84,7 @@ const getOptions = function(pack, outputDir) {
     opts = Object.assign(opts, require('./options-lib'));
   }
 
+  opts.js_output_file = path.join(outputDir, pack.name + '.min.js');
   opts.output_manifest = path.join(outputDir, 'gcc-manifest');
   opts.create_source_map = path.join(outputDir, pack.name + '.min.map');
 

--- a/plugins/gcc/java-writer.js
+++ b/plugins/gcc/java-writer.js
@@ -11,6 +11,10 @@ const genericWriter = function(basePackage, dir, options, file, test) {
   for (var key in options) {
     var value = options[key];
 
+    if (test && key === 'js_output_file') {
+      value = value.replace(basePackage.name + '.min.js', basePackage.name + '-test.min.js');
+    }
+
     if (!(value instanceof Array)) {
       value = [value];
     }
@@ -27,10 +31,6 @@ const genericWriter = function(basePackage, dir, options, file, test) {
       }
     }
   }
-
-  javaArgs.push('--js_output_file');
-  javaArgs.push(path.join(dir, basePackage.name + (test ? '-test' : '') +
-    '.min.js'));
 
   var outputfile = path.join(dir, file);
   console.log('Writing ' + outputfile);

--- a/test/plugins/gcc/index.test.js
+++ b/test/plugins/gcc/index.test.js
@@ -70,6 +70,7 @@ describe('gcc resolver', function() {
 
     var expected = Object.assign({}, require('../../../plugins/gcc/options-base'));
     expected = Object.assign(expected, require('../../../plugins/gcc/options-lib'));
+    expected.js_output_file = path.join(outputDir, pack.name + '.min.js');
     expected.output_manifest = path.join(outputDir, 'gcc-manifest');
     expected.create_source_map = path.join(outputDir, pack.name + '.min.map');
     expected.js = [];

--- a/test/plugins/gcc/java-writer.test.js
+++ b/test/plugins/gcc/java-writer.test.js
@@ -25,7 +25,7 @@ describe('gcc java writer', function() {
         return fs.readFileAsync(file, 'utf-8');
       })
       .then((content) => {
-        expect(content).to.equal('--js_output_file ' + path.join(outputDir, pack.name + '.min.js'));
+        expect(content).to.equal('');
       });
   });
 


### PR DESCRIPTION
Paves the way for `opensphere-build-closure-helper` to use the JS compiler API.