### PR TITLE
Write test options to JSON

### DIFF
--- a/plugins/gcc/test-writer.js
+++ b/plugins/gcc/test-writer.js
@@ -30,7 +30,7 @@ const _getOptions = function(pack, dir, options) {
   var opts = require('./options-test');
   opts.js = options.js ? options.js.slice() : [];
   opts.output_manifest = path.join(dir, 'gcc-test-manifest');
-  opts.js_output_file = options.js_output_file;
+  opts.js_output_file = path.join(dir, pack.name + '-test.min.js');
 
   for (var key in mocks) {
     opts.js.push(mocks[key]);

--- a/plugins/gcc/test-writer.js
+++ b/plugins/gcc/test-writer.js
@@ -2,6 +2,7 @@
 
 const java = require('./java-writer');
 const path = require('path');
+const fs = require('fs');
 
 const getTestDir = function(pack) {
   var testDir = 'test';
@@ -44,8 +45,12 @@ const _getOptions = function(pack, dir, options) {
 };
 
 const writer = function(pack, dir, options) {
-  return java.genericWriter(pack, dir,
-      _getOptions(pack, dir, options), 'gcc-test-args', true);
+  var options = _getOptions(pack, dir, options);
+  var jsonOutput = path.join(dir, 'gcc-test-args.json');
+  return Promise.all([
+    fs.writeFileAsync(jsonOutput, JSON.stringify(options, null, 2)),
+    java.genericWriter(pack, dir, options, 'gcc-test-args', true)
+  ]);
 };
 
 const clear = function() {


### PR DESCRIPTION
Allow using `opensphere-build-closure-helper@3.0.0` to generate test manifests.

Also restores writing the test output file to `<package>-test.min.js` instead of `<package>.min.js`.