### PR TITLE
feat: better windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "resolve": "^1.5.0",
     "rimraf": "^2.5.4",
     "semver": "^5.3.0",
+    "slash": "^3.0.0",
     "underscore": "^1.8.3",
     "yargs": "^11.0.0"
   },

--- a/plugins/copy-onboarding/index.js
+++ b/plugins/copy-onboarding/index.js
@@ -2,6 +2,7 @@
 const Promise = require('bluebird');
 const fs = Promise.promisifyAll(require('fs'));
 const path = require('path');
+const slash = require('slash');
 
 var dirs = [];
 
@@ -25,7 +26,7 @@ const writer = function(thisPackage, dir) {
   if (thisPackage.build.type === 'app') {
     dirs.sort(sort);
     var file = dirs.map(function(item) {
-      return item.path;
+      return slash(item.path);
     }).join('\n');
 
     var filename = path.join(dir, 'copy-onboarding-args');

--- a/plugins/copy-views/index.js
+++ b/plugins/copy-views/index.js
@@ -2,6 +2,7 @@
 const Promise = require('bluebird');
 const fs = Promise.promisifyAll(require('fs'));
 const path = require('path');
+const slash = require('slash');
 
 var dirs = [];
 
@@ -25,7 +26,7 @@ const writer = function(thisPackage, dir) {
   if (thisPackage.build.type === 'app') {
     dirs.sort(sort);
     var file = dirs.map(function(item) {
-      return item.path;
+      return slash(item.path);
     }).join('\n');
 
     var filename = path.join(dir, 'copy-views-args');

--- a/plugins/resources/index.js
+++ b/plugins/resources/index.js
@@ -4,6 +4,7 @@ const fs = Promise.promisifyAll(require('fs'));
 const _ = require('underscore');
 const glob = require('glob');
 const path = require('path');
+const slash = require('slash');
 const utils = require('../../utils');
 
 var debugCss = {};
@@ -227,7 +228,7 @@ const writeFiles = function(obj, dir, baseName) {
   var promises = [];
 
   for (var key in obj) {
-    var files = _.flatten(obj[key]);
+    var files = _.flatten(obj[key]).map(slash);
     var filename = dir + path.sep + baseName + key;
 
     if (files.length) {
@@ -254,11 +255,11 @@ const writer = function(thisPackage, dir) {
     .then(function() {
       const filename = path.join(dir, 'resources-copy-dirs');
       console.log('Writing ' + filename);
-      return fs.writeFileAsync(filename, copyDirs.join('\n'));
+      return fs.writeFileAsync(filename, copyDirs.map(slash).join('\n'));
     })
     .then(function() {
       const content = copyData.map(function(data) {
-        return '"' + data.src + '" "' + data.target + '"';
+        return '"' + slash(data.src) + '" "' + slash(data.target) + '"';
       });
 
       const filename = path.join(dir, 'resources-copy-files');

--- a/test/plugins/copy-onboarding/copy-onboarding.test.js
+++ b/test/plugins/copy-onboarding/copy-onboarding.test.js
@@ -115,4 +115,20 @@ describe('copy onboarding resolver', () => {
         expect(fs.readFileSync(file, 'utf-8')).to.equal(expected.join('\n'));
       });
   });
+
+  it('should normalize win32 paths to forward slashes', ()=> {
+    var pack = {
+      name: 'thing',
+      directories: {
+        onboarding: 'foo\\bar'
+      },
+      build: {
+        type: 'app'
+      }
+    };
+
+    run(pack).then(() => {
+      expect(fs.readFileSync(file, 'utf-8')).to.equal(path.join('foo', 'bar', '*'));
+    });
+  });
 });

--- a/test/plugins/copy-views/copy-views.test.js
+++ b/test/plugins/copy-views/copy-views.test.js
@@ -115,4 +115,20 @@ describe('copy views resolver', () => {
         expect(fs.readFileSync(file, 'utf-8')).to.equal(expected.join('\n'));
       });
   });
+
+  it('should normalize win32 paths to forward slashes', () => {
+    var pack = {
+      name: 'thing',
+      directories: {
+        views: 'foo\\bar'
+      },
+      build: {
+        type: 'app'
+      }
+    };
+
+    run(pack).then(() => {
+      expect(fs.readFileSync(file, 'utf-8')).to.equal(path.join('foo', 'bar', '*'));
+    });
+  });
 });

--- a/test/plugins/resources/index.test.js
+++ b/test/plugins/resources/index.test.js
@@ -19,6 +19,10 @@ describe('resources resolver', () => {
   var outputDir = path.join(process.cwd(), '.test');
   var baseDir = path.join(__dirname, 'resources');
   var dirs = fs.readdirSync(baseDir);
+  var baseDirs = [
+    baseDir,
+    'C:' + baseDir.replace(/\//, '\\')
+  ];
 
   var check = (dir) => {
     var expectedDir = path.join(dir, 'expected');
@@ -76,49 +80,51 @@ describe('resources resolver', () => {
     }
   };
 
-  dirs.forEach((d) => {
-    it(d.replace(/-/g, ' '), () => {
-      return runDir(path.join(baseDir, d));
-    });
-  });
-
-  it('should throw errors for malformed items', () => {
-    expect(runDir.bind(undefined, path.join(__dirname, 'should-error-on-malformed-index'))).to.throw();
-  });
-
-  it('should throw errors for missing items', () => {
-    expect(runDir.bind(undefined, path.join(__dirname, 'should-error-on-missing-index'))).to.throw();
-  });
-
-  it('should throw errors for unmatched glob pattern', () => {
-    expect(runDir(path.join(__dirname, 'should-error-on-unmatched-glob'))).to.be.rejectedWith(Error);
-  });
-
-  it('should not resolve plugins of packages other than the base package', () => {
-    var base = {
-      name: 'base',
-      build: {
-        type: 'app'
-      }
-    };
-
-    var other = {
-      name: 'other-plugin-thing',
-      build: {
-        type: 'plugin',
-        index: 'thing.js'
-      }
-    };
-
-    return resources.resolver(base, path.join(baseDir, 'should-avoid-plugins-not-from-base-package'), 1)
-      .then(() => {
-        resources.resolver(other, path.join(baseDir, 'should-find-and-parse-index-files'), 2);
-      })
-      .then(() => {
-        resources.writer(base, outputDir);
-      }).then(() => {
-        var files = fs.readdirSync(outputDir);
-        expect(files.length).to.equal(0);
+  baseDirs.forEach((baseDir) => {
+    dirs.forEach((d) => {
+      it(d.replace(/-/g, ' '), () => {
+        return runDir(path.join(baseDir, d));
       });
+    });
+
+    it('should throw errors for malformed items', () => {
+      expect(runDir.bind(undefined, path.join(__dirname, 'should-error-on-malformed-index'))).to.throw();
+    });
+
+    it('should throw errors for missing items', () => {
+      expect(runDir.bind(undefined, path.join(__dirname, 'should-error-on-missing-index'))).to.throw();
+    });
+
+    it('should throw errors for unmatched glob pattern', () => {
+      expect(runDir(path.join(__dirname, 'should-error-on-unmatched-glob'))).to.be.rejectedWith(Error);
+    });
+
+    it('should not resolve plugins of packages other than the base package', () => {
+      var base = {
+        name: 'base',
+        build: {
+          type: 'app'
+        }
+      };
+
+      var other = {
+        name: 'other-plugin-thing',
+        build: {
+          type: 'plugin',
+          index: 'thing.js'
+        }
+      };
+
+      return resources.resolver(base, path.join(baseDir, 'should-avoid-plugins-not-from-base-package'), 1)
+        .then(() => {
+          resources.resolver(other, path.join(baseDir, 'should-find-and-parse-index-files'), 2);
+        })
+        .then(() => {
+          resources.writer(base, outputDir);
+        }).then(() => {
+          var files = fs.readdirSync(outputDir);
+          expect(files.length).to.equal(0);
+        });
+    });
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -155,6 +155,11 @@ describe('utils', () => {
     expect(indexPath).to.equal(path.join(modulePath, 'index.js'));
   });
 
+  it('should get the path for a module with win32-like paths', ()=> {
+    var chaiPath = utils.resolveModulePath('@semantic-release\\changelog\\index.js');
+    expect(chaiPath).to.exist;
+  });
+
   it('should find matching lines in a directory', () => {
     var directory = path.join(__dirname, 'utils-find-lines');
     return utils.findLines(/^goog\.provide\(/, directory).then((matches) => {

--- a/utils.js
+++ b/utils.js
@@ -136,7 +136,7 @@ const getPackage = function(packageName) {
  */
 const resolveModulePath = function(modulePath, optBasedir) {
   try {
-    var parts = modulePath.split(path.sep);
+    var parts = modulePath.split(/[\\\/]/);
     if (parts && parts.length) {
       // if the package is scoped, use the first two parts of the path. ie, @scope/package.
       var packageName = parts[0].startsWith('@') ? path.join(parts.shift(), parts.shift()) : parts.shift();
@@ -145,7 +145,7 @@ const resolveModulePath = function(modulePath, optBasedir) {
       }));
 
       // join the remaining path to the resource (if any)
-      return path.join(basePath, parts.join(path.sep));
+      return path.normalize(path.join(basePath, parts.join(path.sep)));
     }
   } catch (e) {
   }


### PR DESCRIPTION
Better support for Windows paths when used in cygwin or Git Bash. Note that you will have to `npm config set script-shell "C:\\path\\to\\bash.exe"` to the bash executable that ships with either of those. Also, `yarn run` is temporarily busted (they have a [fix on master](https://github.com/yarnpkg/yarn/pull/5851)) when using that config so you will need to use `npm run` in the meantime.