### PR TITLE
Fix windows paths 2

### DIFF
--- a/plugins/config/index.js
+++ b/plugins/config/index.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird');
 const fs = Promise.promisifyAll(require('fs'));
 const path = require('path');
 const utils = require('../../utils');
+const slash = require('slash');
 
 var configs = [];
 var basePackage = null;
@@ -105,7 +106,7 @@ const merge = function(from, to) {
 
 const writeDebug = function(pack, outputDir) {
   var overrides = configs.map(function(item) {
-    return item.path;
+    return slash(item.path);
   });
 
   var debug = {

--- a/plugins/gcc/defines.js
+++ b/plugins/gcc/defines.js
@@ -114,7 +114,7 @@ const adder = function(thisPackage, options) {
       // modify ROOT defines with the value
       var list = [];
       for (var key in defines) {
-        list.push(key + '=\'' + value + path.sep + '\'');
+        list.push(key + '=\'' + slash(value + path.sep) + '\'');
       }
 
       if (list.length) {


### PR DESCRIPTION
Fixes `settings-debug.json` override paths and ROOT define paths in `gcc-args.json`.