### PR TITLE
feat: better priority ordering for plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     "yargs": "^11.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.0.0",
+    "@commitlint/config-conventional": "^8.1.0",
+    "@commitlint/travis-cli": "^8.1.0",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/commit-analyzer": "^6.1.0",
     "@semantic-release/git": "^7.0.8",
@@ -105,10 +108,7 @@
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "semantic-release": "^15.13.3",
-    "travis-deploy-once": "^5.0.2",
-    "@commitlint/cli": "^8.0.0",
-    "@commitlint/config-conventional": "^8.1.0",
-    "@commitlint/travis-cli": "^8.1.0"
+    "travis-deploy-once": "^5.0.2"
   },
   "husky": {
     "hooks": {

--- a/plugins.js
+++ b/plugins.js
@@ -63,6 +63,7 @@ const load = function(includes, excludes) {
   return {
     resolvers: plugins.map(mapField('resolver')).filter(filterEmpty),
     writers: plugins.map(mapField('writer')).filter(filterEmpty),
+    updaters: plugins.map(mapField('updater')).filter(filterEmpty),
     postResolvers: plugins.map(mapField('postResolver')).filter(filterEmpty)
   };
 };

--- a/plugins/copy-views/index.js
+++ b/plugins/copy-views/index.js
@@ -2,29 +2,28 @@
 const Promise = require('bluebird');
 const fs = Promise.promisifyAll(require('fs'));
 const path = require('path');
+const utils = require('../../utils');
 const slash = require('slash');
 
 var dirs = [];
 
-var pluginRegex = /-(config|plugin)-/;
-const resolver = function(pack, projectDir, depth) {
+const resolver = function(pack, projectDir, depth, depStack) {
   if (pack.directories && pack.directories.views) {
     dirs.push({
       path: path.join(projectDir, pack.directories.views, '*'),
-      depth: depth - (pluginRegex.test(pack.name) ? 1 : 0)
+      name: pack.name,
+      priority: (pack && pack.build) ? pack.build.priority || 0 : 0,
+      group: utils.getGroup(depStack),
+      depth: depth
     });
   }
 
   return Promise.resolve();
 };
 
-const sort = function(a, b) {
-  return b.depth - a.depth;
-};
-
 const writer = function(thisPackage, dir) {
   if (thisPackage.build.type === 'app') {
-    dirs.sort(sort);
+    dirs.sort(utils.priorityGroupDepthSort);
     var file = dirs.map(function(item) {
       return slash(item.path);
     }).join('\n');
@@ -38,11 +37,12 @@ const writer = function(thisPackage, dir) {
 };
 
 const clear = function() {
-  dirs = [];
+  dirs.length = [];
 };
 
 module.exports = {
   clear: clear,
   resolver: resolver,
+  updater: utils.getGroupDepthUpdater(dirs),
   writer: writer
 };

--- a/plugins/gcc/index.js
+++ b/plugins/gcc/index.js
@@ -19,9 +19,10 @@ var basePackage = null;
  * @param {Object} pack The package
  * @param {string} projectDir The package directory
  * @param {number} depth The resolved depth
+ * @param {Array<string>} depStack the ancestry stack
  * @return {Promise} A promise that resolves when resolution is complete
  */
-const resolver = function(pack, projectDir, depth) {
+const resolver = function(pack, projectDir, depth, depStack) {
   if (utils.isConfigPackage(pack)) {
     return Promise.resolve();
   }
@@ -58,12 +59,20 @@ const resolver = function(pack, projectDir, depth) {
   }
 
   return Promise.all([
-    src.resolver(pack, projectDir, depth),
-    externs.resolver(pack, projectDir, depth),
-    defines.resolver(pack, projectDir, depth),
-    options.resolver(pack, projectDir, depth),
-    tests.resolver(pack, projectDir, depth)
+    src.resolver(pack, projectDir, depth, depStack),
+    externs.resolver(pack, projectDir, depth, depStack),
+    defines.resolver(pack, projectDir, depth, depStack),
+    options.resolver(pack, projectDir, depth, depStack),
+    tests.resolver(pack, projectDir, depth, depStack)
   ]);
+};
+
+const updater = function(pack, depth, depStack) {
+  if (src.updater) src.updater(pack, depth, depStack);
+  if (externs.updater) externs.updater(pack, depth, depStack);
+  if (defines.updater) defines.updater(pack, depth, depStack);
+  if (options.updater) options.updater(pack, depth, depStack);
+  if (tests.updater) tests.updater(pack, depth, depStack);
 };
 
 const postResolver = function(pack, projectDir) {
@@ -128,6 +137,7 @@ const clear = function() {
 module.exports = {
   clear: clear,
   resolver: resolver,
+  updater: updater,
   postResolver: postResolver,
   writer: writer,
   _getOptions: getOptions

--- a/resolve.js
+++ b/resolve.js
@@ -32,7 +32,7 @@ if (!argv.outputDir) {
 var plugins = pluginUtils.load(argv.include, argv.exclude);
 var outputDir = path.resolve(process.cwd(), argv.outputDir);
 
-core.resolvePackage(undefined, undefined, process.cwd(), 0, undefined, plugins)
+core.resolvePackage(undefined, undefined, process.cwd(), 0, undefined, undefined, plugins)
   .then(function() {
     console.log();
 

--- a/test/plugins/copy-onboarding/copy-onboarding.test.js
+++ b/test/plugins/copy-onboarding/copy-onboarding.test.js
@@ -16,7 +16,7 @@ describe('copy onboarding resolver', () => {
   var outputDir = path.join(process.cwd(), '.test');
 
   var run = (pack) => {
-    return copy.resolver(pack, '.', 0).then(() => {
+    return copy.resolver(pack, '.', 0, [pack.name]).then(() => {
       return copy.writer(pack, outputDir);
     });
   };
@@ -102,8 +102,8 @@ describe('copy onboarding resolver', () => {
     };
 
     return Promise.join(
-      copy.resolver(pack1, pack1.name, 0),
-      copy.resolver(pack2, pack2.name, 1))
+      copy.resolver(pack1, pack1.name, 0, ['thing-foo']),
+      copy.resolver(pack2, pack2.name, 1, ['thing-foo', 'thing-foo-plugin-bar']))
       .then(() => {
         return copy.writer(pack1, outputDir);
       })
@@ -127,7 +127,7 @@ describe('copy onboarding resolver', () => {
       }
     };
 
-    run(pack).then(() => {
+    return run(pack).then(() => {
       expect(fs.readFileSync(file, 'utf-8')).to.equal(path.join('foo', 'bar', '*'));
     });
   });

--- a/test/plugins/copy-views/copy-views.test.js
+++ b/test/plugins/copy-views/copy-views.test.js
@@ -16,7 +16,7 @@ describe('copy views resolver', () => {
   var outputDir = path.join(process.cwd(), '.test');
 
   var run = (pack) => {
-    return copy.resolver(pack, '.', 0).then(() => {
+    return copy.resolver(pack, '.', 0, [pack.name]).then(() => {
       return copy.writer(pack, outputDir);
     });
   };
@@ -102,8 +102,8 @@ describe('copy views resolver', () => {
     };
 
     return Promise.join(
-      copy.resolver(pack1, pack1.name, 0),
-      copy.resolver(pack2, pack2.name, 1))
+      copy.resolver(pack1, pack1.name, 0, ['thing-foo']),
+      copy.resolver(pack2, pack2.name, 1, ['thing-foo', 'thing-foo-plugin-bar']))
       .then(() => {
         return copy.writer(pack1, outputDir);
       })
@@ -127,7 +127,7 @@ describe('copy views resolver', () => {
       }
     };
 
-    run(pack).then(() => {
+    return run(pack).then(() => {
       expect(fs.readFileSync(file, 'utf-8')).to.equal(path.join('foo', 'bar', '*'));
     });
   });

--- a/test/plugins/resources/index.test.js
+++ b/test/plugins/resources/index.test.js
@@ -70,7 +70,7 @@ describe('resources resolver', () => {
     }
 
     if (pack) {
-      return resources.resolver(pack, dir, pack.depth || 0)
+      return resources.resolver(pack, dir, pack.depth || 0, [pack.name])
         .then(() => {
           return resources.writer(pack, outputDir);
         })
@@ -115,9 +115,10 @@ describe('resources resolver', () => {
         }
       };
 
-      return resources.resolver(base, path.join(baseDir, 'should-avoid-plugins-not-from-base-package'), 1)
+      return resources.resolver(base, path.join(baseDir, 'should-avoid-plugins-not-from-base-package'), 1, [base.name])
         .then(() => {
-          resources.resolver(other, path.join(baseDir, 'should-find-and-parse-index-files'), 2);
+          resources.resolver(other, path.join(baseDir, 'should-find-and-parse-index-files'), 2,
+            [base.name, other.name]);
         })
         .then(() => {
           resources.writer(base, outputDir);


### PR DESCRIPTION
Plugins can now specify an updater function, which is run when the package has already been resolved once.

The resolver/updater functions now take a forth argument which is the ancestry stack (by package name).

The config and gcc options plugins use those two new features to update the results. Configs are grouped by `BASE` (0), `PLUGIN` (1000), and `CONFIG` (10000). Configs can be promoted to groups in the order `CONFIG` > `PLUGIN` > `BASE` and use the highest depth within their group. The sort value is then `explicitPriority || group - depth`.

Also used the new ancestry stack to clean up the console output.

resolves #7

Given a workspace like so (with dependencies listed):
```
opensphere
opensphere-plugin-something > somelib > opensphere
opensphere-config-test > somelib-config-test
somelib > opensphere
somelib-config-test
```
The previous output of `.build/settings-debug.json` was:
```
{
  "overrides": [
    "../somelib/config/settings.json",
    "config/settings.json",
    "../opensphere-plugin-something/config/settings.json",
    "../somelib-config-test/settings.json",
    "../opensphere-config-test/settings.json"
  ]
}
```
This is poor because `somelib` should be between `opensphere` and the plugin which requires it.

New output:
```
{
  "overrides": [
    "config/settings.json",
    "../somelib/config/settings.json",
    "../opensphere-plugin-something/config/settings.json",
    "../somelib-config-test/settings.json"
    "../opensphere-config-test/settings.json"
  ]
}
```
This same logic is also applied to the GCC options output.

resolves #18 