### PR TITLE
fix(gcc): sort entry_point options by descending priority

### DIFF
--- a/plugins/gcc/options.js
+++ b/plugins/gcc/options.js
@@ -106,7 +106,7 @@ const adder = function(pack, options) {
         value = toArray(value);
 
         if (currValue) {
-          if (key === 'externs') {
+          if (key === 'externs' || key === 'entry_point') {
             options[key] = value.concat(currValue);
           } else {
             options[key] = currValue.concat(value);

--- a/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/expected.json
@@ -4,6 +4,6 @@
   "js": ["src/**.js", "src/after/**.js", "src/before/**.js"],
   "define": ["before=true", "override=after", "main=true", "after=true"],
   "externs": ["a.externs.js", "b.externs.js"],
-  "entry_point": ["before", "one", "two", "after"]
+  "entry_point": ["after", "one", "two", "before"]
 }
 


### PR DESCRIPTION
The debug loader written out by ngageoint/opensphere-build-closure-helper uses `goog.bootstrap` on each `entry_point`, in order, to load the debug application. Plugins/libs need to be loaded before the main application or the additional features they provide may not be available when the application is bootstrapped. By flipping the order, plugins and libs will be loaded into the browser before the main application.