### PR TITLE
feat(gcc): use goog.defines that are assigned to a value

### DIFF
--- a/plugins/gcc/defines.js
+++ b/plugins/gcc/defines.js
@@ -11,7 +11,7 @@ const slash = require('slash');
  *
  * The nice thing about opensphere builds is that there is typically no need to re-run
  * the build to pick up changes to JS or HTML (just hit refresh!). To accomplish
- * this, each project has a goog.defines(<project>.ROOT, '../<project>/') call
+ * this, each project has a goog.define('<project>.ROOT', '../<project>/') call
  * that allows you to prefix paths. e.g. an Angular directive with a template:
  *
  * {
@@ -85,7 +85,7 @@ const resolver = function(pack, projectDir, depth) {
       }
     };
 
-    return utils.findLines(/^goog\.define\(/, dir, /\.js$/).then(function(list) {
+    return utils.findLines(/goog\.define\(/, dir, /\.js$/).then(function(list) {
       list.forEach(processItem);
     });
   }
@@ -161,7 +161,7 @@ const writer = function(thisPackage, outputDir) {
     Object.assign(defs, modules);
 
     // write out the debug file
-    var file = '// This file overrides goog.defines() calls for ' +
+    var file = '// This file overrides goog.define() calls for ' +
         '<project>.*.ROOT defines in the debug html\nvar ' +
         'CLOSURE_UNCOMPILED_DEFINES = ' + JSON.stringify(defs, null, 2) +
         ';';

--- a/test/plugins/gcc/defines/should-use-assigned-define/expected.json
+++ b/test/plugins/gcc/defines/should-use-assigned-define/expected.json
@@ -1,0 +1,1 @@
+["foo.ROOT='test'"]

--- a/test/plugins/gcc/defines/should-use-assigned-define/foo/bar.js
+++ b/test/plugins/gcc/defines/should-use-assigned-define/foo/bar.js
@@ -3,4 +3,4 @@ goog.provide('foo');
 /**
  * @define {string}
  */
-goog.define('foo.ROOT', '');
+foo.ROOT = goog.define('foo.ROOT', '');

--- a/test/plugins/gcc/defines/should-use-assigned-define/package.json
+++ b/test/plugins/gcc/defines/should-use-assigned-define/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "should-use-explicitly-defined-src-directory",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "type": "app"
+  },
+  "directories": {
+    "src": "foo"
+  }
+}

--- a/test/plugins/gcc/defines/should-use-assigned-module-define/expected.json
+++ b/test/plugins/gcc/defines/should-use-assigned-module-define/expected.json
@@ -1,0 +1,1 @@
+["foo.ROOT='test'"]

--- a/test/plugins/gcc/defines/should-use-assigned-module-define/foo/bar.js
+++ b/test/plugins/gcc/defines/should-use-assigned-module-define/foo/bar.js
@@ -1,0 +1,8 @@
+goog.module('foo');
+
+/**
+ * @define {string}
+ */
+const ROOT = goog.define('foo.ROOT', '');
+
+exports = {ROOT};

--- a/test/plugins/gcc/defines/should-use-assigned-module-define/package.json
+++ b/test/plugins/gcc/defines/should-use-assigned-module-define/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "should-use-explicitly-defined-src-directory",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "type": "app"
+  },
+  "directories": {
+    "src": "foo"
+  }
+}


### PR DESCRIPTION
The Closure library now returns the defined value in `goog.define` and no longer automatically assigns the value on `window`. This is intended to allow modules to use the define locally without polluting the window object. This fixes the `goog.define` resolver to match these assignment statements.