### PR TITLE
refactor(goog): update gcc args for 20200112.0.0

### DIFF
--- a/plugins/gcc/options-base.js
+++ b/plugins/gcc/options-base.js
@@ -5,17 +5,19 @@
 /**
 This is from the compiler's help output:
 
-Available Error Groups: accessControls, ambiguousFunctionDecl,
+Available Error Groups: accessControls, checkPrototypalTypes,
     checkRegExp, checkTypes, checkVars, conformanceViolations, const,
-    constantProperty, deprecated, deprecatedAnnotations, duplicateMessage, es3,
-    es5Strict, externsValidation, fileoverviewTags, functionParams, globalThis,
-    internetExplorerChecks, invalidCasts, misplacedTypeAnnotation,
-    missingGetCssName, missingOverride, missingPolyfill, missingProperties,
-    missingProvide, missingRequire, missingReturn, moduleLoad, msgDescriptions,
-    newCheckTypes, nonStandardJsDocs, missingSourcesWarnings,
-    reportUnknownTypes, suspiciousCode, strictModuleDepCheck, typeInvalidation,
-    undefinedNames, undefinedVars, unknownDefines, unusedLocalVariables,
-    unusedPrivateMembers, uselessCode, useOfGoogBase, underscore, visibility
+    constantProperty, deprecated, deprecatedAnnotations, duplicateMessage,
+    es5Strict, externsValidation, functionParams, globalThis, invalidCasts,
+    misplacedTypeAnnotation, missingGetCssName, missingOverride,
+    missingPolyfill, missingProperties, missingProvide, missingRequire,
+    missingReturn, missingSourcesWarnings, moduleLoad, msgDescriptions,
+    nonStandardJsDocs, partialAlias, polymer, reportUnknownTypes,
+    strictCheckTypes, strictMissingProperties, strictModuleDepCheck,
+    strictPrimitiveOperators, suspiciousCode, typeInvalidation, undefinedNames,
+    undefinedVars, underscore, unknownDefines, unusedLocalVariables,
+    unusedPrivateMembers, useOfGoogBase, uselessCode,
+    untranspilableFeatures, visibility
 
 The docs for jscomp_* state that you can use a wildcard. However, that wildcard
 also enables a lot more undocumented items.
@@ -24,7 +26,7 @@ You may just want to check out the list here:
 https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/DiagnosticGroups.java
 */
 module.exports = {
-  dependency_mode: 'STRICT',
+  dependency_mode: 'PRUNE',
   source_map_format: 'V3',
   create_source_map: true,
   summary_detail_level: 3,
@@ -42,7 +44,7 @@ module.exports = {
   // jscomp_error: '*',
   jscomp_error: [
     'accessControls',
-    'ambiguousFunctionDecl',
+    'checkPrototypalTypes',
     'checkRegExp',
     'checkTypes',
     'checkVars',
@@ -52,50 +54,50 @@ module.exports = {
     // 'deprecated',
     'deprecatedAnnotations',
     'duplicateMessage',
-    // 'es3',
     'es5Strict',
     'externsValidation',
-    'fileoverviewTags',
     'functionParams',
     'globalThis',
-    'internetExplorerChecks',
     'invalidCasts',
     'misplacedTypeAnnotation',
     'missingGetCssName',
     'missingOverride',
     'missingPolyfill',
     'missingProperties',
-    // 'missingProvide',
+    'missingProvide',
     'missingRequire',
     'missingReturn',
+    'missingSourcesWarnings',
     'moduleLoad',
     'msgDescriptions',
-    // 'newCheckTypes',
     'nonStandardJsDocs',
-    'missingSourcesWarnings',
+    'partialAlias',
+    'polymer',
     // 'reportUnknownTypes',
-    'suspiciousCode',
+    // 'strictCheckTypes',
+    // 'strictMissingProperties',
     'strictModuleDepCheck',
+    'strictPrimitiveOperators',
+    'suspiciousCode',
     'typeInvalidation',
     'undefinedNames',
     'undefinedVars',
+    'underscore',
     'unknownDefines',
     'unusedLocalVariables',
     'unusedPrivateMembers',
     'useOfGoogBase',
     'uselessCode',
-    'underscore',
+    'untranspilableFeatures',
     'visibility'
   ],
   jscomp_warning: [
-    // If jscomp_error changes to *, you probably want this one
-    // 'lintChecks'
     'deprecated'
   ],
   // TODO: can we get rid of these too?
   jscomp_off: [
-    'es3',
-    'newCheckTypes',
-    'reportUnknownTypes'
+    'reportUnknownTypes',
+    'strictCheckTypes',
+    'strictMissingProperties'
   ]
 };

--- a/plugins/gcc/options-test.js
+++ b/plugins/gcc/options-test.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   compilation_level: 'SIMPLE',
-  dependency_mode: 'LOOSE',
+  dependency_mode: 'PRUNE_LEGACY',
   summary_detail_level: 3,
   jscomp_off: '*'
 };


### PR DESCRIPTION
BREAKING CHANGE: This requires Closure Compiler 20200112.0.0, which is included with opensphere-`build-closure-helper@5.0.0`.

Related PR: https://github.com/ngageoint/opensphere-build-closure-helper/pull/17

- Replace `STRICT/LOOSE` with equivalent `PRUNE/PRUNE_LEGACY` ([commit here](https://github.com/google/closure-compiler/commit/0c8ae0ec822e89aa82f8b7604fd5a68bc30f77ea)).
- Update error groups to the latest set.
- Disable new `strictCheckTypes` and `strictMissingProperties` groups due to an abundance of errors in compiled apps. Enabling these will require a larger refactor than necessary for this update.