### PR TITLE
fix(gcc): add hide_warnings_for to gcc options for tests

### DIFF
--- a/plugins/gcc/options-test.js
+++ b/plugins/gcc/options-test.js
@@ -1,9 +1,9 @@
 'use strict';
 /* eslint camelcase: "off" */
 
-module.exports = {
+module.exports = () => ({
   compilation_level: 'SIMPLE',
   dependency_mode: 'PRUNE_LEGACY',
   summary_detail_level: 3,
   jscomp_off: '*'
-};
+});

--- a/plugins/gcc/test-writer.js
+++ b/plugins/gcc/test-writer.js
@@ -32,6 +32,7 @@ const _getOptions = function(pack, dir, options) {
   opts.js = options.js ? options.js.slice() : [];
   opts.output_manifest = path.join(dir, 'gcc-test-manifest');
   opts.js_output_file = path.join(dir, pack.name + '-test.min.js');
+  opts.hide_warnings_for = options.hide_warnings_for ? options.hide_warnings_for.slice() : [];
 
   for (var key in mocks) {
     opts.js.push(mocks[key]);

--- a/plugins/gcc/test-writer.js
+++ b/plugins/gcc/test-writer.js
@@ -18,7 +18,7 @@ var mocks = {};
 
 const resolver = function(pack, projectDir) {
   if (pack.build) {
-    var testDir = getTestDir();
+    var testDir = getTestDir(pack);
     mocks[pack.name] = path.resolve(projectDir, testDir, '**.mock.js');
   }
 
@@ -28,7 +28,7 @@ const resolver = function(pack, projectDir) {
 const _getOptions = function(pack, dir, options) {
   // the compiler options are not defined in camelcase
   /* eslint camelcase: "off" */
-  var opts = require('./options-test');
+  var opts = require('./options-test')();
   opts.js = options.js ? options.js.slice() : [];
   opts.output_manifest = path.join(dir, 'gcc-test-manifest');
   opts.js_output_file = path.join(dir, pack.name + '-test.min.js');


### PR DESCRIPTION
This PR adds `hide_warnings_for` from the `package.json` to the test options. This was added because OpenLayers references old compiler warning groups, and was introducing unnecessary warnings to the test compilation.

While working this, I realized the `test-writer` tests were incorrectly passing because `require('test-writer')` returns the same instance everywhere it is called. This meant both tests and the resolver were modifying the same instance, so the `expect` calls always passed. The module now exports a function that returns a new instance of the options on each call, and tests have been updated with current intended behavior.

We may want to do this for other options modules, but those were not addressed in this PR.