### PR TITLE
feat(gcc): add goog.SEAL_MODULE_EXPORTS=false for tests

### DIFF
--- a/plugins/gcc/defines.js
+++ b/plugins/gcc/defines.js
@@ -159,20 +159,28 @@ const writer = function(thisPackage, outputDir) {
 
     // add resolved module defines
     Object.assign(defs, modules);
+    const promises = [];
 
-    // write out the debug file
-    var file = '// This file overrides goog.define() calls for ' +
-        '<project>.*.ROOT defines in the debug html\nvar ' +
-        'CLOSURE_UNCOMPILED_DEFINES = ' + JSON.stringify(defs, null, 2) +
-        ';';
-
-    var filename = path.join(outputDir, 'gcc-defines-debug.js');
-    console.log('Writing ' + filename);
-
-    return fs.writeFileAsync(filename, file);
+    promises.push(writeFile(defs, 'gcc-defines-debug.js', outputDir));
+    defs['goog.SEAL_MODULE_EXPORTS'] = false;
+    promises.push(writeFile(defs, 'gcc-defines-test-debug.js', outputDir));
+    return Promise.all(promises);
   }
 
   return Promise.resolve();
+};
+
+const writeFile = (defs, fileName, outputDir) => {
+  // write out the debug file
+  const file = '// This file overrides goog.define() calls for ' +
+      '<project>.*.ROOT defines in the debug html\nvar ' +
+      'CLOSURE_UNCOMPILED_DEFINES = ' + JSON.stringify(defs, null, 2) +
+      ';';
+
+  const filename = path.join(outputDir, fileName);
+  console.log('Writing ' + filename);
+
+  return fs.writeFileAsync(filename, file);
 };
 
 const clear = function() {

--- a/test/plugins/gcc/index.test.js
+++ b/test/plugins/gcc/index.test.js
@@ -8,12 +8,15 @@ const rimraf = require('rimraf');
 const path = require('path');
 
 describe('gcc resolver', function() {
-  afterEach(() => {
+  var outputDir = path.join(process.cwd(), '.test');
+
+  const clear = () => {
     gcc.clear();
     rimraf.sync(path.join(outputDir, '*'));
-  });
+  };
 
-  var outputDir = path.join(process.cwd(), '.test');
+  beforeEach(clear);
+  afterEach(clear);
 
   var fullRun = (pack, dir, optDoWrite) => {
     process.argv.push('--defineRoots');


### PR DESCRIPTION
Adds `goog.SEAL_MODULE_EXPORTS=false` for tests so that tests can more easily spy/replace/mock exported items.