### PR TITLE
fix(utils): only consider plugin/config of root package

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -180,7 +180,8 @@ describe('utils', () => {
     expect(utils.getGroup(['project'])).to.equal(utils.Groups.BASE);
     expect(utils.getGroup(['project', 'project-plugin-test'])).to.equal(utils.Groups.PLUGIN);
     expect(utils.getGroup(['project', 'project-config-test'])).to.equal(utils.Groups.CONFIG);
-    expect(utils.getGroup(['project', 'project-plugin-test-config-test'])).to.equal(utils.Groups.CONFIG);
+    expect(utils.getGroup(['project', 'project-config-test', 'libproject-config-test'])).to.equal(utils.Groups.CONFIG);
+    expect(utils.getGroup(['project', 'project-plugin-test-config-test'])).to.equal(utils.Groups.PLUGIN);
   });
 
   it('should prefer explicit priority', function() {

--- a/utils.js
+++ b/utils.js
@@ -243,14 +243,29 @@ const groups = {
  * @return {number}
  */
 const getGroup = function(depStack) {
+  let group = groups.BASE;
+
   if (depStack) {
-    if (depStack.some((dep) => /-config-/.test(dep))) {
-      return groups.CONFIG;
-    } else if (depStack.some((dep) => /-plugin-/.test(dep))) {
-      return groups.PLUGIN;
+    let rootPackageName;
+    let pluginRegex;
+    let configRegex;
+
+    for (let i = 0, n = depStack.length; i < n; i++) {
+      if (i === 0) {
+        rootPackageName = depStack[i];
+        pluginRegex = new RegExp(`^${rootPackageName}-plugin-`);
+        configRegex = new RegExp(`^${rootPackageName}-config`);
+      } else {
+        if (pluginRegex && pluginRegex.test(depStack[i])) {
+          group = Math.max(group, groups.PLUGIN);
+        } else if (configRegex && configRegex.test(depStack[i])) {
+          group = Math.max(group, groups.CONFIG);
+        }
+      }
     }
   }
-  return groups.BASE;
+
+  return group;
 };
 
 


### PR DESCRIPTION
I was seeing an issue where `project > libproject > other-plugin-x` was sorting `other-plugin-x` in the plugin group even though it is being used as library here and is not a plugin of the project in question.

Instead, what I've done here is require that the group for any particular `depStack` depends on `<rootPackageName>-plugin|config-` rather than just `-plugin|config-`.

This could be marked as a breaking change as plugins or configs getting picked up by folder name but not by package name (package name doesn't match folder name) may no longer be sorted in the same order. It's really minor though so I thought I'd leave that up to review on whether to mark it as such.