### PR TITLE
fix(config): merge delete should always delete

### DIFF
--- a/plugins/config/index.js
+++ b/plugins/config/index.js
@@ -85,12 +85,12 @@ const merge = function(from, to) {
   for (var key in from) {
     var fval = from[key];
 
-    if (key in to) {
+    if (fval === DELETE_VAL) {
+      delete to[key];
+    } else if (key in to) {
       var tval = to[key];
 
-      if (fval === DELETE_VAL) {
-        delete to[key];
-      } else if (isPrimitive(fval) || isPrimitive(tval)) {
+      if (isPrimitive(fval) || isPrimitive(tval)) {
         to[key] = from[key];
       } else {
         merge(fval, tval);


### PR DESCRIPTION
Previously, if the key to delete was not in the object, instead of removing it (aka: do nothing), it would go through the add path and the value would become `"__delete__"`. Not good when you really just wanted to ensure that the default was used.