### PR TITLE
feat(gcc): dedupe arrays in gcc options

### DIFF
--- a/plugins/gcc/options.js
+++ b/plugins/gcc/options.js
@@ -134,6 +134,13 @@ const adder = function(pack, options) {
       list.sort();
     }
   });
+
+  // dedupe arrays in case multiple packages provided the same values.
+  for (var key in options) {
+    if (Array.isArray(options[key])) {
+      options[key] = [...new Set(options[key])];
+    }
+  }
 };
 
 const clear = function() {

--- a/test/plugins/gcc/options/should-combine-packages-correctly/package-duplicates.json
+++ b/test/plugins/gcc/options/should-combine-packages-correctly/package-duplicates.json
@@ -1,0 +1,15 @@
+{
+  "name": "should-combine-packages-correctly-duplicates",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "build": {
+    "gcc": {
+      "js": "src/**.js",
+      "define": ["main=true","override=main"],
+      "externs": ["a.externs.js", "b.externs.js"],
+      "entry_point": ["one", "two"]
+    }
+  }
+}


### PR DESCRIPTION
GCC will error if it encounters duplicate values in array-based options, so dedupe arrays after combining options from all packages.