### PR TITLE
feat(webpack): write files to support webpack builds

### DIFF
--- a/plugins/gcc/index.js
+++ b/plugins/gcc/index.js
@@ -9,6 +9,7 @@ const builder = require('./builder-writer');
 const java = require('./java-writer');
 const json = require('./json-writer');
 const tests = require('./test-writer');
+const webpack = require('./webpack-writer');
 const path = require('path');
 const utils = require('../../utils.js');
 
@@ -122,7 +123,8 @@ const writer = function(pack, outputDir) {
     java.writer(pack, outputDir, options),
     json.writer(pack, outputDir, options),
     defines.writer(pack, outputDir, options),
-    tests.writer(pack, outputDir, options)
+    tests.writer(pack, outputDir, options),
+    webpack.writer(pack, outputDir, options)
   ]);
 };
 

--- a/plugins/gcc/webpack-writer.js
+++ b/plugins/gcc/webpack-writer.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+const path = require('path');
+
+/**
+ * Properties written by closure-webpack-plugin that should be omitted from the output.
+ * @type {!Array<string>}
+ */
+const closureWebpackInternalProps = [
+  'create_source_map',
+  'dependency_mode',
+  'entry_point',
+  'js',
+  'js_output_file',
+  'module',
+  'module_resolution',
+  'output_manifest',
+  'output_wrapper'
+];
+
+/**
+ * Write support files for webpack.
+ * @param {Object} basePackage The base package.
+ * @param {string} dir The output directory.
+ * @param {Object} options The Closure Compiler options.
+ * @return {Promise} Promise that resolves when all files have been written.
+ */
+const writer = function(basePackage, dir, options) {
+  const promises = [];
+
+  //
+  // Translate the entry_point list into a webpack entry file.
+  //
+  let entryPoints = options.entry_point;
+  if (entryPoints && !Array.isArray(entryPoints)) {
+    entryPoints = [entryPoints];
+  }
+
+  if (entryPoints && entryPoints.length) {
+    const entryPoints = Array.isArray(options.entry_point) ? options.entry_point : [options.entry_point];
+    const indexContent = entryPoints
+      .map((ep) => `goog.require('${ep.replace(/^goog:/, '')}');`)
+      .join('\n');
+
+    const indexFile = path.join(dir, 'index.js');
+    console.log('Writing ' + indexFile);
+    promises.push(fs.writeFileAsync(indexFile, indexContent));
+  } else {
+    throw new Error(`No entry_point defined in GCC options for ${basePackage.name}`);
+  }
+
+  //
+  // Generate Closure Compiler options for webpack.
+  //
+  const webpackOptions = Object.assign({}, options);
+  closureWebpackInternalProps.forEach((prop) => {
+    delete webpackOptions[prop];
+  });
+
+  const outputfile = path.join(dir, 'gcc-webpack.json');
+  console.log('Writing ' + outputfile);
+  promises.push(fs.writeFileAsync(outputfile, JSON.stringify(webpackOptions, null, 2)));
+
+  return Promise.all(promises);
+};
+
+module.exports = {
+  writer: writer
+};

--- a/test/plugins/gcc/json-writer.test.js
+++ b/test/plugins/gcc/json-writer.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const Promise = require('bluebird');
+const expect = require('chai').expect;
+const fs = Promise.promisifyAll(require('fs'));
+const json = require('../../../plugins/gcc/json-writer');
+const rimraf = require('rimraf');
+const path = require('path');
+
+describe('gcc json writer', function() {
+  var outputDir = path.join(process.cwd(), '.test');
+  var file = path.join(outputDir, 'gcc-args.json');
+
+  afterEach(() => {
+    rimraf.sync(file);
+  });
+
+  var pack = {
+    name: 'thing'
+  };
+
+  it('should handle empty options', function() {
+    return json.writer(pack, outputDir, {})
+      .then(() => {
+        return fs.readFileAsync(file, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.exist;
+      });
+  });
+
+  it('should write options to a file', function() {
+    var jsonOptions = {
+      angular_pass: true,
+      compilation_level: 'simple',
+      js: ['a.js', 'b.js'],
+      jscomp_error: 'accessControls',
+      jscomp_off: 'es6',
+      jscomp_warning: 'useOfGoogBase'
+    };
+
+    return json.writer(pack, outputDir, jsonOptions)
+      .then(() => {
+        return fs.readFileAsync(file, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.equal(JSON.stringify(jsonOptions, null, 2));
+      });
+  });
+});

--- a/test/plugins/gcc/webpack-writer.test.js
+++ b/test/plugins/gcc/webpack-writer.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const Promise = require('bluebird');
+const expect = require('chai').expect;
+const fs = Promise.promisifyAll(require('fs'));
+const webpack = require('../../../plugins/gcc/webpack-writer');
+const rimraf = require('rimraf');
+const path = require('path');
+
+describe('gcc webpack writer', function() {
+  var outputDir = path.join(process.cwd(), '.test');
+
+  var indexFile = path.join(outputDir, 'index.js');
+  var optionsFile = path.join(outputDir, 'gcc-webpack.json');
+
+  afterEach(() => {
+    rimraf.sync(indexFile);
+    rimraf.sync(optionsFile);
+  });
+
+  var pack = {
+    name: 'thing'
+  };
+
+  var writeFn = (pack, dir, options) => {
+    return webpack.writer(pack, dir, options);
+  };
+
+  it('should throw on missing entry_point', function() {
+    expect(writeFn.bind(undefined, pack, outputDir, {})).to.throw();
+    expect(writeFn.bind(undefined, pack, outputDir, {entry_point: ''})).to.throw();
+    expect(writeFn.bind(undefined, pack, outputDir, {entry_point: []})).to.throw();
+  });
+
+  it('should handle empty options', function() {
+    return webpack.writer(pack, outputDir, {
+      entry_point: ['goog:ns']
+    })
+      .then(() => {
+        return fs.readFileAsync(optionsFile, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.exist;
+      });
+  });
+
+  it('should write options to a file', function() {
+    var jsonOptions = {
+      angular_pass: true,
+      compilation_level: 'simple',
+      entry_point: ['goog:ns'],
+      jscomp_error: 'accessControls',
+      jscomp_off: 'es6',
+      jscomp_warning: 'useOfGoogBase'
+    };
+
+    var expectedOptions = {
+      angular_pass: true,
+      compilation_level: 'simple',
+      jscomp_error: 'accessControls',
+      jscomp_off: 'es6',
+      jscomp_warning: 'useOfGoogBase'
+    };
+
+    return webpack.writer(pack, outputDir, jsonOptions)
+      .then(() => {
+        return fs.readFileAsync(optionsFile, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.equal(JSON.stringify(expectedOptions, null, 2));
+      });
+  });
+
+  it('should remove options handled by webpack', function() {
+    var jsonOptions = {
+      compilation_level: 'advanced',
+      create_source_map: 'test',
+      dependency_mode: 'test',
+      entry_point: 'goog:ns',
+      js: ['a.js', 'b.js'],
+      js_output_file: 'test',
+      module: 'test',
+      module_resolution: 'test',
+      output_manifest: 'test',
+      output_wrapper: 'test'
+    };
+
+    var expectedOptions = {
+      compilation_level: 'advanced'
+    };
+
+    return webpack.writer(pack, outputDir, jsonOptions)
+      .then(() => {
+        return fs.readFileAsync(optionsFile, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.equal(JSON.stringify(expectedOptions, null, 2));
+      });
+  });
+
+  it('should write index to a file', function() {
+    var jsonOptions = {
+      entry_point: ['goog:ns1', 'goog:ns2']
+    };
+
+    var expectedContent = `goog.require('ns1');\ngoog.require('ns2');`;
+
+    return webpack.writer(pack, outputDir, jsonOptions)
+      .then(() => {
+        return fs.readFileAsync(indexFile, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.equal(expectedContent);
+      });
+  });
+});


### PR DESCRIPTION
This PR adds a webpack writer to support use of [closure-webpack-plugin](https://webpack.js.org/plugins/closure-webpack-plugin/) in OpenSphere builds.

The writer creates two files:

- JSON options object to pass to the webpack compiler plugin. All options handled internally by the webpack plugin are removed from the original GCC options generated by the resolver.
- An `index.js` file to use as the webpack `entry`. This file has `goog.require` statements for each `entry_point` from the GCC options.

Tests were added for the new webpack writer and the existing JSON writer.