### PR TITLE
feat(gcc): update error groups for gcc 20200830.0.0

### DIFF
--- a/plugins/gcc/options-base.js
+++ b/plugins/gcc/options-base.js
@@ -9,15 +9,14 @@ Available Error Groups: accessControls, checkPrototypalTypes,
     checkRegExp, checkTypes, checkVars, conformanceViolations, const,
     constantProperty, deprecated, deprecatedAnnotations, duplicateMessage,
     es5Strict, externsValidation, functionParams, globalThis, invalidCasts,
-    misplacedTypeAnnotation, missingGetCssName, missingOverride,
-    missingPolyfill, missingProperties, missingProvide, missingRequire,
-    missingReturn, missingSourcesWarnings, moduleLoad, msgDescriptions,
+    misplacedTypeAnnotation, missingOverride, missingPolyfill,
+    missingProperties, missingProvide, missingRequire, missingReturn,
+    missingSourcesWarnings, moduleLoad, moduleImports, msgDescriptions,
     nonStandardJsDocs, partialAlias, polymer, reportUnknownTypes,
     strictCheckTypes, strictMissingProperties, strictModuleDepCheck,
     strictPrimitiveOperators, suspiciousCode, typeInvalidation, undefinedNames,
     undefinedVars, underscore, unknownDefines, unusedLocalVariables,
-    unusedPrivateMembers, useOfGoogBase, uselessCode,
-    untranspilableFeatures, visibility
+    unusedPrivateMembers, uselessCode, untranspilableFeatures, visibility
 
 The docs for jscomp_* state that you can use a wildcard. However, that wildcard
 also enables a lot more undocumented items.
@@ -86,7 +85,6 @@ module.exports = {
     'unknownDefines',
     'unusedLocalVariables',
     'unusedPrivateMembers',
-    'useOfGoogBase',
     'uselessCode',
     'untranspilableFeatures',
     'visibility'

--- a/test/plugins/gcc/java-writer.test.js
+++ b/test/plugins/gcc/java-writer.test.js
@@ -36,7 +36,7 @@ describe('gcc java writer', function() {
       js: ['a.js', 'b.js'],
       jscomp_error: 'accessControls',
       jscomp_off: 'es6',
-      jscomp_warning: 'useOfGoogBase'
+      jscomp_warning: 'deprecated'
     })
       .then(() => {
         return fs.readFileAsync(file, 'utf-8');
@@ -49,7 +49,7 @@ describe('gcc java writer', function() {
         expect(content).to.contain('--js=\'b.js\'');
         expect(content).to.contain('--jscomp_error=\'accessControls\'');
         expect(content).to.contain('--jscomp_off=\'es6\'');
-        expect(content).to.contain('--jscomp_warning=\'useOfGoogBase\'');
+        expect(content).to.contain('--jscomp_warning=\'deprecated\'');
       });
   });
 });

--- a/test/plugins/gcc/json-writer.test.js
+++ b/test/plugins/gcc/json-writer.test.js
@@ -36,7 +36,7 @@ describe('gcc json writer', function() {
       js: ['a.js', 'b.js'],
       jscomp_error: 'accessControls',
       jscomp_off: 'es6',
-      jscomp_warning: 'useOfGoogBase'
+      jscomp_warning: 'deprecated'
     };
 
     return json.writer(pack, outputDir, jsonOptions)

--- a/test/plugins/gcc/webpack-writer.test.js
+++ b/test/plugins/gcc/webpack-writer.test.js
@@ -51,7 +51,7 @@ describe('gcc webpack writer', function() {
       entry_point: ['goog:ns'],
       jscomp_error: 'accessControls',
       jscomp_off: 'es6',
-      jscomp_warning: 'useOfGoogBase'
+      jscomp_warning: 'deprecated'
     };
 
     var expectedOptions = {
@@ -59,7 +59,7 @@ describe('gcc webpack writer', function() {
       compilation_level: 'simple',
       jscomp_error: 'accessControls',
       jscomp_off: 'es6',
-      jscomp_warning: 'useOfGoogBase'
+      jscomp_warning: 'deprecated'
     };
 
     return webpack.writer(pack, outputDir, jsonOptions)


### PR DESCRIPTION
Closure Compiler 20200830.0.0 removes the `useOfGoogBase` error group. This will no longer report the error in projects on an older compiler, but it is preferred that projects update to the latest version of the compiler via `opensphere-build-closure-helper@6.0.0` (ngageoint/opensphere-build-closure-helper/pull/23).