### PR TITLE
feat(es6): detect es6 modules using goog.declareModuleId

### DIFF
--- a/plugins/gcc/src.js
+++ b/plugins/gcc/src.js
@@ -7,7 +7,7 @@ const utils = require('../../utils');
 
 var srcPaths = [];
 
-var provideModuleRegexp = /^goog\.(module|provide)\(/;
+var provideModuleRegexp = /^goog\.(declareModuleId|module|provide)\(/;
 
 var shortcuts = {
   'google-closure-library': function(pack, projectDir) {


### PR DESCRIPTION
This adds support for detecting Closure namespaces defined in an ES6 module using `goog.declareModuleId`.

See Closure's ES6 migration docs here for details:
https://github.com/google/closure-compiler/wiki/Migrating-from-goog.modules-to-ES6-modules