### PR TITLE
feat(gcc): write webpack entry point for test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "resolve.js",
   "scripts": {
-    "test:run": "nyc _mocha --recursive 'test/**/*.test.js'",
+    "test:run": "nyc _mocha --recursive 'test/**/!(exclude)*.test.js'",
     "test": "mkdirp .test && npm run test:run && rimraf .test",
     "lint": "eslint '**/*.js'",
     "package:update": "if git diff --name-only ORIG_HEAD HEAD | grep --quiet package.json; then echo 'UPDATE: package.json changed, consider running yarn in your workspace root'; fi",

--- a/plugins/gcc/index.js
+++ b/plugins/gcc/index.js
@@ -81,7 +81,10 @@ const postResolver = function(pack, projectDir) {
     return Promise.resolve();
   }
 
-  return src.postResolver(pack, projectDir);
+  return Promise.all([
+    src.postResolver(pack, projectDir),
+    tests.postResolver(pack, projectDir)
+  ]);
 };
 
 const getOptions = function(pack, outputDir) {

--- a/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/index-test.js
+++ b/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/index-test.js
@@ -1,0 +1,13 @@
+goog.provide('libcomp');
+/* eslint no-undef: "off" */
+
+goog.require('dep1');
+goog.require('dep2');
+goog.require('dep3');
+goog.require('dep4');
+goog.require('dep5');
+
+/**
+ * Default library entry point
+ */
+libcomp.test = function() {};

--- a/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/package.json
+++ b/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "should-create-test-index-with-test-dir",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "directories": {
+    "src": "foo",
+    "lib": "bar",
+    "test": "test"
+  },
+  "build": {
+    "type": "lib"
+  }
+}

--- a/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/test/exclude-a.test.js
+++ b/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/test/exclude-a.test.js
@@ -1,0 +1,3 @@
+goog.require('dep1');
+goog.require('dep2');
+goog.require('dep3');

--- a/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/test/subdir/exclude-b.test.js
+++ b/test/plugins/gcc/test-writer/should-create-test-index-with-test-dir/test/subdir/exclude-b.test.js
@@ -1,0 +1,3 @@
+goog.require('dep3');
+goog.require('dep4');
+goog.require('dep5');

--- a/test/plugins/gcc/test-writer/should-not-create-test-index-without-test-dir/package.json
+++ b/test/plugins/gcc/test-writer/should-not-create-test-index-without-test-dir/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "should-not-create-test-index-without-test-dir",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "directories": {
+    "src": "foo",
+    "lib": "bar",
+    "test": "test"
+  },
+  "build": {
+    "type": "lib"
+  }
+}


### PR DESCRIPTION
In support of loading ES6 modules as test dependencies, we want to bundle all dependencies with webpack. Doing so removes the need for a script/module loader, currently `karma-test-loader.js` from `opensphere-build-index`. Instead of using a loader, the dependency bundle and all tests can be loaded directly in the Karma config.

This change writes an entry point for webpack that includes all unique `goog.require` statements from test files in the base project being resolved. For the time being, this assumes ES6 modules will use `goog.declareModuleId` so they can be included with `goog.require` and `goog.module.get`. Without that call, test files would have to use `import` or `require` which I don't believe we'll be ready to support until our code is fully transitioned to ES6 modules.