### PR TITLE
feat(webpack): generate output manifest in webpack build

### DIFF
--- a/plugins/gcc/webpack-writer.js
+++ b/plugins/gcc/webpack-writer.js
@@ -16,7 +16,6 @@ const closureWebpackInternalProps = [
   'js_output_file',
   'module',
   'module_resolution',
-  'output_manifest',
   'output_wrapper'
 ];
 

--- a/test/plugins/gcc/webpack-writer.test.js
+++ b/test/plugins/gcc/webpack-writer.test.js
@@ -86,7 +86,8 @@ describe('gcc webpack writer', function() {
     };
 
     var expectedOptions = {
-      compilation_level: 'advanced'
+      compilation_level: 'advanced',
+      output_manifest: 'test'
     };
 
     return webpack.writer(pack, outputDir, jsonOptions)


### PR DESCRIPTION
I mistakenly excluded `output_manifest` from the webpack GCC options, but a manifest can be useful for debugging the build.

The official option exclusion list from the [plugin docs](https://webpack.js.org/plugins/closure-webpack-plugin/) is:

```
module_resolution
output_wrapper
dependency_mode
create_source_map
module
entry_point
```

We also exclude `js` and `js_output_file` because these are controlled by the plugin, despite not being explicitly stated.