### PR TITLE
feat(ol): sort ol.ext entry point to the top if present

### DIFF
--- a/plugins/gcc/webpack-writer.js
+++ b/plugins/gcc/webpack-writer.js
@@ -20,6 +20,21 @@ const closureWebpackInternalProps = [
 ];
 
 /**
+ * Entry point for the ol.ext provide. This file fixes a compiler issue and needs to be loaded first if present.
+ * @type {string}
+ */
+const olExtEntryPoint = 'goog:ol.ext';
+
+/**
+ * Sort entry points. Brings the ol.ext entry point to the top of the list, and leaves remaining entry points in their
+ * original order.
+ * @param {string} a First entry point.
+ * @param {string} b Second entry point.
+ * @return {number} The sort order.
+ */
+const sortEntryPoints = (a, b) => a === olExtEntryPoint ? -1 : b === olExtEntryPoint ? 1 : 0;
+
+/**
  * Write support files for webpack.
  * @param {Object} basePackage The base package.
  * @param {string} dir The output directory.
@@ -40,6 +55,7 @@ const writer = function(basePackage, dir, options) {
   if (entryPoints && entryPoints.length) {
     const entryPoints = Array.isArray(options.entry_point) ? options.entry_point : [options.entry_point];
     const indexContent = entryPoints
+      .sort(sortEntryPoints)
       .map((ep) => `goog.require('${ep.replace(/^goog:/, '')}');`)
       .join('\n');
 

--- a/test/plugins/gcc/webpack-writer.test.js
+++ b/test/plugins/gcc/webpack-writer.test.js
@@ -114,4 +114,20 @@ describe('gcc webpack writer', function() {
         expect(content).to.equal(expectedContent);
       });
   });
+
+  it('should sort ol.ext as the first entry point', function() {
+    var jsonOptions = {
+      entry_point: ['goog:ns1', 'goog:ol.ext', 'goog:ns2']
+    };
+
+    var expectedContent = `goog.require('ol.ext');\ngoog.require('ns1');\ngoog.require('ns2');`;
+
+    return webpack.writer(pack, outputDir, jsonOptions)
+      .then(() => {
+        return fs.readFileAsync(indexFile, 'utf-8');
+      })
+      .then((content) => {
+        expect(content).to.equal(expectedContent);
+      });
+  });
 });


### PR DESCRIPTION
This goes along with ngageoint/opensphere/pull/1341 to sort the `ol.ext` entry point to the top of the generated webpack entry point, `index.js`. That entry point needs to be loaded first, so if plugins contribute entry points they previously would have been added before the main app entry points. With this change, `ol.ext` will be sorted to the top and the remaining order will be unchanged.